### PR TITLE
Add Stripe subscription checkout and webhook handling

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -9,6 +9,7 @@ module.exports = (sequelize) => {
       username: { type: DataTypes.STRING, allowNull: false, unique: true },
       password: { type: DataTypes.STRING, allowNull: false },
       role: { type: DataTypes.STRING, allowNull: false },
+      subscriptionStatus: { type: DataTypes.STRING, defaultValue: 'inactive' },
     },
     {
       hooks: {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,8 @@
         "pg-hstore": "^2.3.4",
         "sequelize": "^6.37.7",
         "sequelize-cli": "^6.6.3",
-        "sqlite3": "^5.1.6"
+        "sqlite3": "^5.1.6",
+        "stripe": "^18.4.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -3220,6 +3221,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.4.0.tgz",
+      "integrity": "sha512-LKFeDnDYo4U/YzNgx2Lc9PT9XgKN0JNF1iQwZxgkS4lOw5NunWCnzyH5RhTlD3clIZnf54h7nyMWkS8VXPmtTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.7",
     "sequelize-cli": "^6.6.3",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "stripe": "^18.4.0"
   }
 }

--- a/backend/routes/payments.js
+++ b/backend/routes/payments.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const Stripe = require('stripe');
+
+const router = express.Router();
+const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
+
+router.post('/create-checkout-session', auth, async (req, res) => {
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [
+        {
+          price: process.env.STRIPE_PRICE_ID,
+          quantity: 1,
+        },
+      ],
+      success_url: `${process.env.FRONTEND_URL}/success`,
+      cancel_url: `${process.env.FRONTEND_URL}/cancel`,
+      subscription_data: {
+        metadata: { userId: req.user.id },
+      },
+    });
+
+    res.json({ id: session.id, url: session.url });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,9 +7,14 @@ const offerRoutes = require('./routes/offers');
 const rfqRoutes = require('./routes/rfqs');
 const marketDataRoutes = require('./routes/marketData');
 const messageRoutes = require('./routes/messages');
+const paymentRoutes = require('./routes/payments');
+const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
 app.use(cors());
+
+app.post('/webhooks/stripe', express.raw({ type: 'application/json' }), stripeWebhook);
+
 app.use(express.json());
 
 app.use('/api/v1/auth', authRoutes);
@@ -17,6 +22,7 @@ app.use('/api/v1/offers', offerRoutes);
 app.use('/api/v1/rfqs', rfqRoutes);
 app.use('/api/v1/market-data', marketDataRoutes);
 app.use('/api/v1/messages', messageRoutes);
+app.use('/api/v1/payments', paymentRoutes);
 
 app.get('/', (req, res) => {
   res.send('FalconTrade Backend is running');

--- a/backend/webhooks/stripe.js
+++ b/backend/webhooks/stripe.js
@@ -1,0 +1,42 @@
+const Stripe = require('stripe');
+const { User } = require('../models');
+
+const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
+
+module.exports = async (req, res) => {
+  const sig = req.headers['stripe-signature'];
+  let event;
+
+  try {
+    event = stripe.webhooks.constructEvent(
+      req.body,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET
+    );
+  } catch (err) {
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  const subscription = event.data.object;
+  const userId = subscription?.metadata?.userId;
+
+  if (userId) {
+    const user = await User.findByPk(userId);
+    if (user) {
+      switch (event.type) {
+        case 'customer.subscription.deleted':
+          user.subscriptionStatus = 'canceled';
+          break;
+        case 'customer.subscription.created':
+        case 'customer.subscription.updated':
+          user.subscriptionStatus = subscription.status;
+          break;
+        default:
+          break;
+      }
+      await user.save();
+    }
+  }
+
+  res.json({ received: true });
+};


### PR DESCRIPTION
## Summary
- add Stripe dependency and payments route to create checkout sessions
- add Stripe webhook for subscription status updates
- track user subscription status

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dbcfd08fc832597dbfe2e0bdbd07f