### PR TITLE
Add listings models and admin CRUD with messaging links

### DIFF
--- a/backend/models/Message.js
+++ b/backend/models/Message.js
@@ -6,6 +6,8 @@ module.exports = (sequelize) => {
     fromUserId: { type: DataTypes.INTEGER, allowNull: false },
     toUserId: { type: DataTypes.INTEGER, allowNull: false },
     content: { type: DataTypes.TEXT, allowNull: false },
+    offerId: { type: DataTypes.INTEGER, allowNull: true },
+    rfqId: { type: DataTypes.INTEGER, allowNull: true },
   });
   return Message;
 };

--- a/backend/models/Offer.js
+++ b/backend/models/Offer.js
@@ -7,6 +7,11 @@ module.exports = (sequelize) => {
     symbol: { type: DataTypes.STRING, allowNull: false },
     price: { type: DataTypes.FLOAT, allowNull: false },
     quantity: { type: DataTypes.INTEGER, allowNull: false },
+    status: {
+      type: DataTypes.ENUM('pending', 'approved', 'featured'),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
   });
   return Offer;
 };

--- a/backend/models/RFQ.js
+++ b/backend/models/RFQ.js
@@ -6,7 +6,11 @@ module.exports = (sequelize) => {
     userId: { type: DataTypes.INTEGER, allowNull: false },
     symbol: { type: DataTypes.STRING, allowNull: false },
     quantity: { type: DataTypes.INTEGER, allowNull: false },
-    status: { type: DataTypes.STRING, allowNull: false, defaultValue: 'open' },
+    status: {
+      type: DataTypes.ENUM('pending', 'approved', 'featured'),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
   });
   return RFQ;
 };

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -18,6 +18,12 @@ User.hasMany(Message, { as: 'receivedMessages', foreignKey: 'toUserId' });
 Message.belongsTo(User, { as: 'fromUser', foreignKey: 'fromUserId' });
 Message.belongsTo(User, { as: 'toUser', foreignKey: 'toUserId' });
 
+Offer.hasMany(Message, { foreignKey: 'offerId' });
+Message.belongsTo(Offer, { foreignKey: 'offerId' });
+
+RFQ.hasMany(Message, { foreignKey: 'rfqId' });
+Message.belongsTo(RFQ, { foreignKey: 'rfqId' });
+
 module.exports = {
   sequelize,
   User,

--- a/backend/routes/messages.js
+++ b/backend/routes/messages.js
@@ -1,10 +1,39 @@
 const express = require('express');
+const { Op } = require('sequelize');
 const auth = require('../middleware/auth');
+const { Message } = require('../models');
 
 const router = express.Router();
 
-router.get('/', auth, (req, res) => {
-  res.json({ message: 'Messages endpoint' });
+// Send a message referencing an offer or RFQ
+router.post('/', auth, async (req, res) => {
+  try {
+    const { toUserId, content, offerId, rfqId } = req.body;
+    const message = await Message.create({
+      fromUserId: req.user.id,
+      toUserId,
+      content,
+      offerId,
+      rfqId,
+    });
+    res.json(message);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Get all messages for the authenticated user
+router.get('/', auth, async (req, res) => {
+  const messages = await Message.findAll({
+    where: {
+      [Op.or]: [
+        { fromUserId: req.user.id },
+        { toUserId: req.user.id },
+      ],
+    },
+  });
+  res.json(messages);
 });
 
 module.exports = router;
+

--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -1,10 +1,82 @@
 const express = require('express');
 const auth = require('../middleware/auth');
+const { isAdmin } = require('../middleware/roles');
+const { Offer } = require('../models');
 
 const router = express.Router();
 
-router.get('/', auth, (req, res) => {
-  res.json({ message: 'Offers endpoint' });
+// Create a new offer
+router.post('/', auth, async (req, res) => {
+  try {
+    const { symbol, price, quantity } = req.body;
+    const offer = await Offer.create({
+      userId: req.user.id,
+      symbol,
+      price,
+      quantity,
+    });
+    res.json(offer);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Get all offers
+router.get('/', auth, async (req, res) => {
+  const offers = await Offer.findAll();
+  res.json(offers);
+});
+
+// Get a single offer
+router.get('/:id', auth, async (req, res) => {
+  const offer = await Offer.findByPk(req.params.id);
+  if (!offer) {
+    return res.status(404).json({ message: 'Offer not found' });
+  }
+  res.json(offer);
+});
+
+// Update an offer (admin only)
+router.put('/:id', auth, isAdmin, async (req, res) => {
+  const offer = await Offer.findByPk(req.params.id);
+  if (!offer) {
+    return res.status(404).json({ message: 'Offer not found' });
+  }
+  await offer.update(req.body);
+  res.json(offer);
+});
+
+// Delete an offer (admin only)
+router.delete('/:id', auth, isAdmin, async (req, res) => {
+  const offer = await Offer.findByPk(req.params.id);
+  if (!offer) {
+    return res.status(404).json({ message: 'Offer not found' });
+  }
+  await offer.destroy();
+  res.json({ message: 'Offer deleted' });
+});
+
+// Approve an offer (admin only)
+router.post('/:id/approve', auth, isAdmin, async (req, res) => {
+  const offer = await Offer.findByPk(req.params.id);
+  if (!offer) {
+    return res.status(404).json({ message: 'Offer not found' });
+  }
+  offer.status = 'approved';
+  await offer.save();
+  res.json(offer);
+});
+
+// Feature an offer (admin only)
+router.post('/:id/feature', auth, isAdmin, async (req, res) => {
+  const offer = await Offer.findByPk(req.params.id);
+  if (!offer) {
+    return res.status(404).json({ message: 'Offer not found' });
+  }
+  offer.status = 'featured';
+  await offer.save();
+  res.json(offer);
 });
 
 module.exports = router;
+

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -1,10 +1,81 @@
 const express = require('express');
 const auth = require('../middleware/auth');
+const { isAdmin } = require('../middleware/roles');
+const { RFQ } = require('../models');
 
 const router = express.Router();
 
-router.get('/', auth, (req, res) => {
-  res.json({ message: 'RFQs endpoint' });
+// Create a new RFQ
+router.post('/', auth, async (req, res) => {
+  try {
+    const { symbol, quantity } = req.body;
+    const rfq = await RFQ.create({
+      userId: req.user.id,
+      symbol,
+      quantity,
+    });
+    res.json(rfq);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Get all RFQs
+router.get('/', auth, async (req, res) => {
+  const rfqs = await RFQ.findAll();
+  res.json(rfqs);
+});
+
+// Get a single RFQ
+router.get('/:id', auth, async (req, res) => {
+  const rfq = await RFQ.findByPk(req.params.id);
+  if (!rfq) {
+    return res.status(404).json({ message: 'RFQ not found' });
+  }
+  res.json(rfq);
+});
+
+// Update an RFQ (admin only)
+router.put('/:id', auth, isAdmin, async (req, res) => {
+  const rfq = await RFQ.findByPk(req.params.id);
+  if (!rfq) {
+    return res.status(404).json({ message: 'RFQ not found' });
+  }
+  await rfq.update(req.body);
+  res.json(rfq);
+});
+
+// Delete an RFQ (admin only)
+router.delete('/:id', auth, isAdmin, async (req, res) => {
+  const rfq = await RFQ.findByPk(req.params.id);
+  if (!rfq) {
+    return res.status(404).json({ message: 'RFQ not found' });
+  }
+  await rfq.destroy();
+  res.json({ message: 'RFQ deleted' });
+});
+
+// Approve an RFQ (admin only)
+router.post('/:id/approve', auth, isAdmin, async (req, res) => {
+  const rfq = await RFQ.findByPk(req.params.id);
+  if (!rfq) {
+    return res.status(404).json({ message: 'RFQ not found' });
+  }
+  rfq.status = 'approved';
+  await rfq.save();
+  res.json(rfq);
+});
+
+// Feature an RFQ (admin only)
+router.post('/:id/feature', auth, isAdmin, async (req, res) => {
+  const rfq = await RFQ.findByPk(req.params.id);
+  if (!rfq) {
+    return res.status(404).json({ message: 'RFQ not found' });
+  }
+  rfq.status = 'featured';
+  await rfq.save();
+  res.json(rfq);
 });
 
 module.exports = router;
+


### PR DESCRIPTION
## Summary
- add Offer and RFQ models with status tracking
- implement CRUD routes for offers and RFQs including admin approve and feature
- allow messages to reference offers or RFQs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dc046bac88325987f74670380e30c