### PR TITLE
Add authentication context and pages

### DIFF
--- a/frontend/contexts/AuthContext.js
+++ b/frontend/contexts/AuthContext.js
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(null);
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const storedToken = typeof window !== 'undefined' && localStorage.getItem('token');
+    const storedUser = typeof window !== 'undefined' && localStorage.getItem('user');
+    if (storedToken) setToken(storedToken);
+    if (storedUser) setUser(JSON.parse(storedUser));
+  }, []);
+
+  const login = (jwt, userData) => {
+    setToken(jwt);
+    setUser(userData);
+    localStorage.setItem('token', jwt);
+    localStorage.setItem('user', JSON.stringify(userData));
+  };
+
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,9 @@
+import { AuthProvider } from '../contexts/AuthContext';
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <AuthProvider>
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,4 +1,20 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function Home() {
+  const { token } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!token) {
+      router.replace('/login');
+    }
+  }, [token, router]);
+
+  if (!token) {
+    return null;
+  }
+
   return <h1>FalconTrade Frontend is running</h1>;
 }

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useAuth } from '../contexts/AuthContext';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+  const { login } = useAuth();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/v1/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      login(data.token, { username });
+      router.push('/');
+    } else {
+      alert('Login failed');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Username:</label>
+        <input value={username} onChange={(e) => setUsername(e.target.value)} />
+      </div>
+      <div>
+        <label>Password:</label>
+        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      </div>
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/frontend/pages/signup.js
+++ b/frontend/pages/signup.js
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Signup() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('user');
+  const router = useRouter();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('http://localhost:5000/api/v1/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password, role }),
+    });
+    if (res.ok) {
+      router.push('/login');
+    } else {
+      alert('Signup failed');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Username:</label>
+        <input value={username} onChange={(e) => setUsername(e.target.value)} />
+      </div>
+      <div>
+        <label>Password:</label>
+        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      </div>
+      <div>
+        <label>Role:</label>
+        <input value={role} onChange={(e) => setRole(e.target.value)} />
+      </div>
+      <button type="submit">Signup</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add React context to store auth token and user details
- create login and signup pages posting to backend auth endpoints
- protect home route, redirecting unauthenticated users to login

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc1ebb0ac83258bc0883a4c7d6921