### PR TITLE
Add project overview and gitignore for env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
-node_modules
-backend/node_modules
-frontend/node_modules
+# Dependencies
+node_modules/
+
+# Next.js build output
+.next/
+
+# Environment files
+.env
+.env.*
+
+# Local database
 backend/database.sqlite
-frontend/.next

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# FalconTrade
+
+FalconTrade is a full-stack trading platform combining an Express backend and a Next.js frontend.
+
+## Project Structure
+- `backend/` – Express API server. See the [backend setup guide](./backend/README.md).
+- `frontend/` – Next.js client application. See the [frontend setup guide](./frontend/README.md).
+
+## Deployment
+
+### Render (Backend)
+Deploy the Express API to [Render](https://render.com):
+1. Create a new Web Service and connect the `backend` directory.
+2. Set the build command to `npm install` and the start command to `npm start`.
+3. Configure the following environment variables:
+   - `DATABASE_URL`
+   - `STRIPE_SECRET_KEY`
+   - `STRIPE_WEBHOOK_SECRET`
+   - `STRIPE_PRICE_ID`
+   - `FRONTEND_URL`
+   - `JWT_SECRET`
+   - `PORT` (optional)
+
+### Vercel (Frontend)
+Deploy the Next.js app to [Vercel](https://vercel.com):
+1. Import the repository and select the `frontend` directory.
+2. Set the build command to `npm run build` and the output directory to `.next`.
+3. Configure the following environment variables:
+   - `NEXT_PUBLIC_API_URL`
+   - `NEXT_PUBLIC_STRIPE_PUBLIC_KEY`
+
+Environment variables on Vercel must be prefixed with `NEXT_PUBLIC_` to be accessible in the browser.


### PR DESCRIPTION
## Summary
- document project structure and deployment notes in root README
- ignore node modules, Next.js build output, and environment files

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dc7cd5fbc8325a61f114517839c1d