### PR TITLE
Use HTTP-only cookies for authentication

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
@@ -675,6 +676,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -26,9 +26,32 @@ router.post('/login', async (req, res) => {
       process.env.JWT_SECRET || 'secret',
       { expiresIn: '1h' }
     );
-    res.json({ token });
+    res.cookie('token', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 3600000,
+    });
+    res.json({ id: user.id, username: user.username, role: user.role });
   } catch (err) {
     res.status(500).json({ message: err.message });
+  }
+});
+
+router.get('/me', async (req, res) => {
+  const token = req.cookies && req.cookies.token;
+  if (!token) {
+    return res.status(401).json({ message: 'Not authenticated' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const user = await User.findByPk(decoded.id);
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+    res.json({ id: user.id, username: user.username, role: user.role });
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
   }
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const cookieParser = require('cookie-parser');
 const { sequelize } = require('./models');
 
 const authRoutes = require('./routes/auth');
@@ -11,7 +12,8 @@ const paymentRoutes = require('./routes/payments');
 const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
-app.use(cors());
+app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
+app.use(cookieParser());
 
 app.post('/webhooks/stripe', express.raw({ type: 'application/json' }), stripeWebhook);
 

--- a/frontend/contexts/AuthContext.js
+++ b/frontend/contexts/AuthContext.js
@@ -7,24 +7,31 @@ export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    const storedToken = typeof window !== 'undefined' && localStorage.getItem('token');
-    const storedUser = typeof window !== 'undefined' && localStorage.getItem('user');
-    if (storedToken) setToken(storedToken);
-    if (storedUser) setUser(JSON.parse(storedUser));
+    const fetchUser = async () => {
+      try {
+        const res = await fetch('http://localhost:5000/api/v1/auth/me', {
+          credentials: 'include',
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setUser(data);
+          setToken(true);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchUser();
   }, []);
 
-  const login = (jwt, userData) => {
-    setToken(jwt);
+  const login = (userData) => {
     setUser(userData);
-    localStorage.setItem('token', jwt);
-    localStorage.setItem('user', JSON.stringify(userData));
+    setToken(true);
   };
 
   const logout = () => {
-    setToken(null);
     setUser(null);
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
+    setToken(null);
   };
 
   return (

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -12,11 +12,12 @@ export default function Login() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post('http://localhost:5000/api/v1/auth/login', {
-        username,
-        password,
-      });
-      login(res.data.token, res.data.user);
+      const res = await axios.post(
+        'http://localhost:5000/api/v1/auth/login',
+        { username, password },
+        { withCredentials: true }
+      );
+      login(res.data);
       router.push('/');
     } catch (err) {
       alert('Login failed');


### PR DESCRIPTION
## Summary
- issue JWT as http-only cookie on login and expose `/api/v1/auth/me` endpoint to return basic user data
- add cookie parser and CORS credentials support to backend server
- fetch logged-in user via `/api/v1/auth/me` on the client and handle login responses without storing tokens

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm test` (frontend) *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_689dcd28a60083258c67700b447bdfb2