### PR TITLE
Add email verification and password reset flow

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -10,6 +10,8 @@ module.exports = (sequelize) => {
       password: { type: DataTypes.STRING, allowNull: false },
       role: { type: DataTypes.STRING, allowNull: false },
       subscriptionStatus: { type: DataTypes.STRING, defaultValue: 'inactive' },
+      verificationToken: { type: DataTypes.STRING },
+      resetToken: { type: DataTypes.STRING },
     },
     {
       hooks: {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.9.13",
     "pg": "^8.16.3",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.7",

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,13 +1,43 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
+const nodemailer = require('nodemailer');
 const { User } = require('../models');
 
 const router = express.Router();
 
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: process.env.SMTP_PORT,
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
 router.post('/signup', async (req, res) => {
   const { username, password, role } = req.body;
   try {
-    const user = await User.create({ username, password, role });
+    const verificationToken = crypto.randomBytes(32).toString('hex');
+    const user = await User.create({
+      username,
+      password,
+      role,
+      verificationToken,
+    });
+
+    try {
+      await transporter.sendMail({
+        to: username,
+        from: process.env.SMTP_FROM || 'no-reply@falcontrade.com',
+        subject: 'Verify your email',
+        text: `Click to verify your email: http://localhost:3000/verify-email?token=${verificationToken}`,
+      });
+    } catch (mailErr) {
+      console.error('Error sending verification email', mailErr);
+    }
+
     res.json({ id: user.id, username: user.username, role: user.role });
   } catch (err) {
     res.status(400).json({ message: err.message });
@@ -52,6 +82,63 @@ router.get('/me', async (req, res) => {
     res.json({ id: user.id, username: user.username, role: user.role });
   } catch (err) {
     res.status(401).json({ message: 'Invalid token' });
+  }
+});
+
+router.get('/verify-email', async (req, res) => {
+  const { token } = req.query;
+  try {
+    const user = await User.findOne({ where: { verificationToken: token } });
+    if (!user) {
+      return res.status(400).json({ message: 'Invalid token' });
+    }
+    user.verificationToken = null;
+    await user.save();
+    res.json({ message: 'Email verified' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+router.post('/forgot-password', async (req, res) => {
+  const { email } = req.body;
+  try {
+    const user = await User.findOne({ where: { username: email } });
+    if (!user) {
+      return res.status(400).json({ message: 'No user found with that email' });
+    }
+    const resetToken = crypto.randomBytes(32).toString('hex');
+    user.resetToken = resetToken;
+    await user.save();
+    try {
+      await transporter.sendMail({
+        to: email,
+        from: process.env.SMTP_FROM || 'no-reply@falcontrade.com',
+        subject: 'Password Reset',
+        text: `Reset your password: http://localhost:3000/reset-password?token=${resetToken}`,
+      });
+    } catch (mailErr) {
+      console.error('Error sending reset email', mailErr);
+    }
+    res.json({ message: 'Password reset email sent' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+router.post('/reset-password', async (req, res) => {
+  const { token, password } = req.body;
+  try {
+    const user = await User.findOne({ where: { resetToken: token } });
+    if (!user) {
+      return res.status(400).json({ message: 'Invalid token' });
+    }
+    user.password = password;
+    user.resetToken = null;
+    await user.save();
+    res.json({ message: 'Password updated' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
   }
 });
 

--- a/frontend/pages/forgot-password.js
+++ b/frontend/pages/forgot-password.js
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await axios.post('http://localhost:5000/api/v1/auth/forgot-password', {
+        email,
+      });
+      setMessage('Check your email for a reset link.');
+    } catch (err) {
+      setMessage('Unable to send reset email.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Email:</label>
+        <input value={email} onChange={(e) => setEmail(e.target.value)} />
+      </div>
+      <button type="submit">Send Reset Link</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}
+

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -35,6 +35,9 @@ export default function Login() {
         <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
       </div>
       <button type="submit">Login</button>
+      <div>
+        <a href="/forgot-password">Forgot password?</a>
+      </div>
     </form>
   );
 }

--- a/frontend/pages/reset-password.js
+++ b/frontend/pages/reset-password.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import axios from 'axios';
+
+export default function ResetPassword() {
+  const router = useRouter();
+  const { token } = router.query;
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await axios.post('http://localhost:5000/api/v1/auth/reset-password', {
+        token,
+        password,
+      });
+      setMessage('Password updated. You can now log in.');
+    } catch (err) {
+      setMessage('Unable to reset password.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>New Password:</label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      <button type="submit">Reset Password</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}
+

--- a/frontend/pages/verify-email.js
+++ b/frontend/pages/verify-email.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import axios from 'axios';
+
+export default function VerifyEmail() {
+  const router = useRouter();
+  const { token } = router.query;
+  const [message, setMessage] = useState('Verifying...');
+
+  useEffect(() => {
+    if (!token) return;
+    const verify = async () => {
+      try {
+        await axios.get(
+          `http://localhost:5000/api/v1/auth/verify-email?token=${token}`
+        );
+        setMessage('Email verified successfully.');
+      } catch (err) {
+        setMessage('Verification failed.');
+      }
+    };
+    verify();
+  }, [token]);
+
+  return <p>{message}</p>;
+}
+


### PR DESCRIPTION
## Summary
- add nodemailer to backend and send verification emails on signup
- support email verification, password reset request and password update routes
- create frontend pages for verifying email and resetting forgotten passwords

## Testing
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689dce61047c8325aa7ac6dabcceaf83