### PR TITLE
Add public landing pages and navigation

### DIFF
--- a/frontend/components/PublicNav.js
+++ b/frontend/components/PublicNav.js
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function PublicNav() {
+  return (
+    <nav className="p-4 space-x-4 bg-gray-100 dark:bg-gray-800">
+      <Link href="/">Home</Link>
+      <Link href="/about">About</Link>
+      <Link href="/pricing">Pricing</Link>
+      <Link href="/faq">FAQ</Link>
+      <Link href="/contact">Contact</Link>
+      <Link href="/login">Login</Link>
+      <Link href="/signup">Sign Up</Link>
+    </nav>
+  );
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,14 +1,23 @@
 import '../styles/globals.css';
-import { AuthProvider } from '../contexts/AuthContext';
+import { AuthProvider, useAuth } from '../contexts/AuthContext';
 import ThemeToggle from '../components/ThemeToggle';
+import PublicNav from '../components/PublicNav';
+
+function AppContent({ Component, pageProps }) {
+  const { token } = useAuth();
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-900 text-black dark:text-white">
+      <ThemeToggle />
+      {!token && <PublicNav />}
+      <Component {...pageProps} />
+    </div>
+  );
+}
 
 export default function MyApp({ Component, pageProps }) {
   return (
     <AuthProvider>
-      <div className="min-h-screen bg-white dark:bg-gray-900 text-black dark:text-white">
-        <ThemeToggle />
-        <Component {...pageProps} />
-      </div>
+      <AppContent Component={Component} pageProps={pageProps} />
     </AuthProvider>
   );
 }

--- a/frontend/pages/about.js
+++ b/frontend/pages/about.js
@@ -1,0 +1,8 @@
+export default function About() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl mb-4">About FalconTrade</h1>
+      <p>FalconTrade helps you stay informed and manage your investments with ease.</p>
+    </div>
+  );
+}

--- a/frontend/pages/contact.js
+++ b/frontend/pages/contact.js
@@ -1,0 +1,8 @@
+export default function Contact() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl mb-4">Contact Us</h1>
+      <p>Get in touch with the FalconTrade team.</p>
+    </div>
+  );
+}

--- a/frontend/pages/faq.js
+++ b/frontend/pages/faq.js
@@ -1,0 +1,8 @@
+export default function FAQ() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl mb-4">Frequently Asked Questions</h1>
+      <p>Find answers to common questions about FalconTrade.</p>
+    </div>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,20 +1,24 @@
-import { useEffect } from 'react';
-import { useRouter } from 'next/router';
-import { useAuth } from '../contexts/AuthContext';
+import Link from 'next/link';
 
 export default function Home() {
-  const { token } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!token) {
-      router.replace('/login');
-    }
-  }, [token, router]);
-
-  if (!token) {
-    return null;
-  }
-
-  return <h1>FalconTrade Frontend is running</h1>;
+  return (
+    <div className="p-8">
+      <h1 className="text-4xl mb-4">Welcome to FalconTrade</h1>
+      <p className="mb-4">Track the markets and manage your portfolio with ease.</p>
+      <ul className="list-disc pl-5 space-y-2">
+        <li>
+          <Link href="/about">Learn more about us</Link>
+        </li>
+        <li>
+          <Link href="/pricing">View pricing plans</Link>
+        </li>
+        <li>
+          <Link href="/faq">Read our FAQ</Link>
+        </li>
+        <li>
+          <Link href="/contact">Contact us</Link>
+        </li>
+      </ul>
+    </div>
+  );
 }

--- a/frontend/pages/pricing.js
+++ b/frontend/pages/pricing.js
@@ -1,0 +1,8 @@
+export default function Pricing() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl mb-4">Pricing</h1>
+      <p>Choose a plan that fits your trading needs.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create about, pricing, faq, and contact pages
- replace index redirect with landing page linking to public routes
- add public navigation for unauthenticated users

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dcf80a1608325ae1316534016c0ea