### PR TITLE
Add watchlist and news endpoints with Sequelize models

### DIFF
--- a/backend/models/NewsItem.js
+++ b/backend/models/NewsItem.js
@@ -1,0 +1,11 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const NewsItem = sequelize.define('NewsItem', {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    title: { type: DataTypes.STRING, allowNull: false },
+    content: { type: DataTypes.TEXT, allowNull: false },
+    publishedAt: { type: DataTypes.DATE, allowNull: false },
+  });
+  return NewsItem;
+};

--- a/backend/models/WatchlistItem.js
+++ b/backend/models/WatchlistItem.js
@@ -1,0 +1,11 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const WatchlistItem = sequelize.define('WatchlistItem', {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    userId: { type: DataTypes.INTEGER, allowNull: false },
+    symbol: { type: DataTypes.STRING, allowNull: false },
+    price: { type: DataTypes.FLOAT, allowNull: false },
+  });
+  return WatchlistItem;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -5,6 +5,8 @@ const Offer = require('./Offer')(sequelize);
 const RFQ = require('./RFQ')(sequelize);
 const MarketData = require('./MarketData')(sequelize);
 const Message = require('./Message')(sequelize);
+const WatchlistItem = require('./WatchlistItem')(sequelize);
+const NewsItem = require('./NewsItem')(sequelize);
 
 // Associations
 User.hasMany(Offer, { foreignKey: 'userId' });
@@ -17,6 +19,9 @@ User.hasMany(Message, { as: 'sentMessages', foreignKey: 'fromUserId' });
 User.hasMany(Message, { as: 'receivedMessages', foreignKey: 'toUserId' });
 Message.belongsTo(User, { as: 'fromUser', foreignKey: 'fromUserId' });
 Message.belongsTo(User, { as: 'toUser', foreignKey: 'toUserId' });
+
+User.hasMany(WatchlistItem, { foreignKey: 'userId' });
+WatchlistItem.belongsTo(User, { foreignKey: 'userId' });
 
 Offer.hasMany(Message, { foreignKey: 'offerId' });
 Message.belongsTo(Offer, { foreignKey: 'offerId' });
@@ -31,4 +36,6 @@ module.exports = {
   RFQ,
   MarketData,
   Message,
+  WatchlistItem,
+  NewsItem,
 };

--- a/backend/routes/news.js
+++ b/backend/routes/news.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const { isAdmin } = require('../middleware/roles');
+const { NewsItem } = require('../models');
+
+const router = express.Router();
+
+// Get all news items
+router.get('/', auth, async (req, res) => {
+  const items = await NewsItem.findAll();
+  res.json(items);
+});
+
+// Create a news item (admin only)
+router.post('/', auth, isAdmin, async (req, res) => {
+  try {
+    const { title, content, publishedAt } = req.body;
+    const item = await NewsItem.create({ title, content, publishedAt });
+    res.status(201).json(item);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Update a news item (admin only)
+router.put('/:id', auth, isAdmin, async (req, res) => {
+  const item = await NewsItem.findByPk(req.params.id);
+  if (!item) {
+    return res.status(404).json({ message: 'News not found' });
+  }
+  await item.update(req.body);
+  return res.json(item);
+});
+
+// Delete a news item (admin only)
+router.delete('/:id', auth, isAdmin, async (req, res) => {
+  const item = await NewsItem.findByPk(req.params.id);
+  if (!item) {
+    return res.status(404).json({ message: 'News not found' });
+  }
+  await item.destroy();
+  return res.json({ message: 'News deleted' });
+});
+
+module.exports = router;

--- a/backend/routes/watchlist.js
+++ b/backend/routes/watchlist.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const { WatchlistItem } = require('../models');
+
+const router = express.Router();
+
+// Get watchlist items for the authenticated user
+router.get('/', auth, async (req, res) => {
+  const items = await WatchlistItem.findAll({ where: { userId: req.user.id } });
+  res.json(items);
+});
+
+// Add a new watchlist item
+router.post('/', auth, async (req, res) => {
+  try {
+    const { symbol, price } = req.body;
+    const item = await WatchlistItem.create({ userId: req.user.id, symbol, price });
+    res.status(201).json(item);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// Update a watchlist item
+router.put('/:id', auth, async (req, res) => {
+  const item = await WatchlistItem.findOne({ where: { id: req.params.id, userId: req.user.id } });
+  if (!item) {
+    return res.status(404).json({ message: 'Item not found' });
+  }
+  await item.update(req.body);
+  return res.json(item);
+});
+
+// Delete a watchlist item
+router.delete('/:id', auth, async (req, res) => {
+  const item = await WatchlistItem.findOne({ where: { id: req.params.id, userId: req.user.id } });
+  if (!item) {
+    return res.status(404).json({ message: 'Item not found' });
+  }
+  await item.destroy();
+  return res.json({ message: 'Item deleted' });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
-const { sequelize } = require('./models');
+const { sequelize, WatchlistItem, NewsItem } = require('./models');
 
 const authRoutes = require('./routes/auth');
 const offerRoutes = require('./routes/offers');
@@ -9,6 +9,8 @@ const rfqRoutes = require('./routes/rfqs');
 const marketDataRoutes = require('./routes/marketData');
 const messageRoutes = require('./routes/messages');
 const paymentRoutes = require('./routes/payments');
+const watchlistRoutes = require('./routes/watchlist');
+const newsRoutes = require('./routes/news');
 const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
@@ -25,12 +27,34 @@ app.use('/api/v1/rfqs', rfqRoutes);
 app.use('/api/v1/market-data', marketDataRoutes);
 app.use('/api/v1/messages', messageRoutes);
 app.use('/api/v1/payments', paymentRoutes);
+app.use('/api/v1/watchlist', watchlistRoutes);
+app.use('/api/v1/news', newsRoutes);
 
 app.get('/', (req, res) => {
   res.send('FalconTrade Backend is running');
 });
 
 const PORT = process.env.PORT || 5000;
-sequelize.sync().then(() => {
+sequelize.sync().then(async () => {
+  if (await WatchlistItem.count() === 0) {
+    await WatchlistItem.bulkCreate([
+      { userId: 1, symbol: 'AAPL', price: 150 },
+      { userId: 1, symbol: 'GOOGL', price: 2800 },
+    ]);
+  }
+  if (await NewsItem.count() === 0) {
+    await NewsItem.bulkCreate([
+      {
+        title: 'Welcome to FalconTrade',
+        content: 'Stay tuned for updates',
+        publishedAt: new Date(),
+      },
+      {
+        title: 'Trading Tips',
+        content: 'Remember to diversify your portfolio.',
+        publishedAt: new Date(),
+      },
+    ]);
+  }
   app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 });

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -51,10 +51,21 @@ function Dashboard() {
           </LineChart>
         </ResponsiveContainer>
       </div>
+      <h2 className="text-xl mt-8 mb-2">Watchlist Items</h2>
+      <ul>
+        {watchlist.map((item) => (
+          <li key={item.id}>
+            {item.symbol}: {item.price}
+          </li>
+        ))}
+      </ul>
       <h2 className="text-xl mt-8 mb-2">Latest News</h2>
       <ul>
         {news.map((item) => (
-          <li key={item.id}>{item.title}</li>
+          <li key={item.id}>
+            <strong>{item.title}</strong>
+            <p>{item.content}</p>
+          </li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- implement WatchlistItem and NewsItem Sequelize models with associations and seeding
- add CRUD routes for watchlist and news and register them with the server
- extend dashboard to render returned watchlist and news data

## Testing
- `cd backend && npm test` (fails: Missing script "test")
- `cd frontend && npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689dd0ebf08883259f2320529d80cfc0