### PR TITLE
feat: add admin metrics and management endpoints

### DIFF
--- a/backend/controllers/admin.js
+++ b/backend/controllers/admin.js
@@ -1,0 +1,84 @@
+const { User, Offer } = require('../models');
+
+async function getMetrics(req, res) {
+  try {
+    const userCount = await User.count();
+    const approvedOffers = await Offer.findAll({ where: { status: 'approved' } });
+    const totalRevenue = approvedOffers.reduce(
+      (sum, offer) => sum + offer.price * offer.quantity,
+      0,
+    );
+    const pendingListings = await Offer.count({ where: { status: 'pending' } });
+    res.json({ userCount, totalRevenue, pendingListings });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getUsers(req, res) {
+  try {
+    const users = await User.findAll();
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function deleteUser(req, res) {
+  try {
+    const user = await User.findByPk(req.params.id);
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    await user.destroy();
+    return res.json({ message: 'User deleted' });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+async function getListings(req, res) {
+  try {
+    const offers = await Offer.findAll();
+    res.json(offers);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function approveListing(req, res) {
+  try {
+    const offer = await Offer.findByPk(req.params.id);
+    if (!offer) {
+      return res.status(404).json({ message: 'Listing not found' });
+    }
+    offer.status = 'approved';
+    await offer.save();
+    res.json(offer);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function deleteListing(req, res) {
+  try {
+    const offer = await Offer.findByPk(req.params.id);
+    if (!offer) {
+      return res.status(404).json({ message: 'Listing not found' });
+    }
+    await offer.destroy();
+    res.json({ message: 'Listing deleted' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  getMetrics,
+  getUsers,
+  deleteUser,
+  getListings,
+  approveListing,
+  deleteListing,
+};
+

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const { isAdmin } = require('../middleware/roles');
+const {
+  getMetrics,
+  getUsers,
+  deleteUser,
+  getListings,
+  approveListing,
+  deleteListing,
+} = require('../controllers/admin');
+
+const router = express.Router();
+
+router.get('/metrics', auth, isAdmin, getMetrics);
+router.get('/users', auth, isAdmin, getUsers);
+router.delete('/users/:id', auth, isAdmin, deleteUser);
+router.get('/listings', auth, isAdmin, getListings);
+router.post('/listings/:id/approve', auth, isAdmin, approveListing);
+router.delete('/listings/:id', auth, isAdmin, deleteListing);
+
+module.exports = router;
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const messageRoutes = require('./routes/messages');
 const paymentRoutes = require('./routes/payments');
 const watchlistRoutes = require('./routes/watchlist');
 const newsRoutes = require('./routes/news');
+const adminRoutes = require('./routes/admin');
 const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
@@ -29,6 +30,7 @@ app.use('/api/v1/messages', messageRoutes);
 app.use('/api/v1/payments', paymentRoutes);
 app.use('/api/v1/watchlist', watchlistRoutes);
 app.use('/api/v1/news', newsRoutes);
+app.use('/api/v1/admin', adminRoutes);
 
 app.get('/', (req, res) => {
   res.send('FalconTrade Backend is running');


### PR DESCRIPTION
## Summary
- add admin controller to aggregate metrics, manage users and listings
- expose admin routes for metrics, user management, and listing approval/deletion
- mount admin routes under `/api/v1/admin`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689dd211b3d08325812d2f1c7f3c63c4