### PR TITLE
Enforce active subscriptions for subscriber features

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -2,7 +2,7 @@ const jwt = require('jsonwebtoken');
 const { User } = require('../models');
 
 // Middleware to verify JWT tokens and attach the user to the request
-module.exports = async function auth(req, res, next) {
+async function auth(req, res, next) {
   const authHeader = req.headers['authorization'];
   if (!authHeader) {
     return res.status(401).json({ message: 'No token provided' });
@@ -20,5 +20,25 @@ module.exports = async function auth(req, res, next) {
   } catch (err) {
     res.status(401).json({ message: 'Invalid token' });
   }
-};
+}
+
+// Ensure the authenticated user has an active subscription
+function requireActiveSubscription(req, res, next) {
+  if (
+    req.user &&
+    req.user.role === 'subscriber' &&
+    req.user.subscriptionStatus !== 'active'
+  ) {
+    return res
+      .status(403)
+      .json({ message: 'Subscription inactive' });
+  }
+  next();
+}
+
+// Export the auth function with an additional helper for subscription checks
+auth.requireActiveSubscription = requireActiveSubscription;
+
+module.exports = auth;
+
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -38,7 +38,12 @@ router.post('/signup', async (req, res) => {
       console.error('Error sending verification email', mailErr);
     }
 
-    res.json({ id: user.id, username: user.username, role: user.role });
+    res.json({
+      id: user.id,
+      username: user.username,
+      role: user.role,
+      subscriptionStatus: user.subscriptionStatus,
+    });
   } catch (err) {
     res.status(400).json({ message: err.message });
   }
@@ -62,7 +67,12 @@ router.post('/login', async (req, res) => {
       sameSite: 'lax',
       maxAge: 3600000,
     });
-    res.json({ id: user.id, username: user.username, role: user.role });
+    res.json({
+      id: user.id,
+      username: user.username,
+      role: user.role,
+      subscriptionStatus: user.subscriptionStatus,
+    });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }
@@ -79,7 +89,12 @@ router.get('/me', async (req, res) => {
     if (!user) {
       return res.status(401).json({ message: 'Invalid token' });
     }
-    res.json({ id: user.id, username: user.username, role: user.role });
+    res.json({
+      id: user.id,
+      username: user.username,
+      role: user.role,
+      subscriptionStatus: user.subscriptionStatus,
+    });
   } catch (err) {
     res.status(401).json({ message: 'Invalid token' });
   }

--- a/backend/routes/marketData.js
+++ b/backend/routes/marketData.js
@@ -1,11 +1,17 @@
 const express = require('express');
 const auth = require('../middleware/auth');
-const { isAdmin } = require('../middleware/roles');
+const { isAdmin, isSubscriber } = require('../middleware/roles');
 const marketDataController = require('../controllers/marketData');
 
 const router = express.Router();
 
-router.get('/:commodity', auth, marketDataController.getMarketData);
+router.get(
+  '/:commodity',
+  auth,
+  isSubscriber,
+  auth.requireActiveSubscription,
+  marketDataController.getMarketData
+);
 router.post('/:commodity', auth, isAdmin, marketDataController.addMarketData);
 router.put('/:commodity', auth, isAdmin, marketDataController.updateMarketData);
 

--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -1,12 +1,12 @@
 const express = require('express');
 const auth = require('../middleware/auth');
-const { isAdmin } = require('../middleware/roles');
+const { isAdmin, isSubscriber } = require('../middleware/roles');
 const { Offer } = require('../models');
 
 const router = express.Router();
 
 // Create a new offer
-router.post('/', auth, async (req, res) => {
+router.post('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
   try {
     const { symbol, price, quantity } = req.body;
     const offer = await Offer.create({
@@ -22,13 +22,13 @@ router.post('/', auth, async (req, res) => {
 });
 
 // Get all offers
-router.get('/', auth, async (req, res) => {
+router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
   const offers = await Offer.findAll();
   res.json(offers);
 });
 
 // Get a single offer
-router.get('/:id', auth, async (req, res) => {
+router.get('/:id', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
   const offer = await Offer.findByPk(req.params.id);
   if (!offer) {
     return res.status(404).json({ message: 'Offer not found' });

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -1,12 +1,12 @@
 const express = require('express');
 const auth = require('../middleware/auth');
-const { isAdmin } = require('../middleware/roles');
+const { isAdmin, isSubscriber } = require('../middleware/roles');
 const { RFQ } = require('../models');
 
 const router = express.Router();
 
 // Create a new RFQ
-router.post('/', auth, async (req, res) => {
+router.post('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
   try {
     const { symbol, quantity } = req.body;
     const rfq = await RFQ.create({
@@ -21,13 +21,13 @@ router.post('/', auth, async (req, res) => {
 });
 
 // Get all RFQs
-router.get('/', auth, async (req, res) => {
+router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
   const rfqs = await RFQ.findAll();
   res.json(rfqs);
 });
 
 // Get a single RFQ
-router.get('/:id', auth, async (req, res) => {
+router.get('/:id', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
   const rfq = await RFQ.findByPk(req.params.id);
   if (!rfq) {
     return res.status(404).json({ message: 'RFQ not found' });

--- a/frontend/components/withAuth.js
+++ b/frontend/components/withAuth.js
@@ -12,10 +12,19 @@ export default function withAuth(Component, requiredRole) {
         router.replace('/login');
       } else if (requiredRole && user?.role !== requiredRole) {
         router.replace('/');
+      } else if (
+        user?.role === 'subscriber' &&
+        user.subscriptionStatus !== 'active'
+      ) {
+        router.replace('/pricing');
       }
     }, [token, user, router]);
 
-    if (!token || (requiredRole && user?.role !== requiredRole)) {
+    if (
+      !token ||
+      (requiredRole && user?.role !== requiredRole) ||
+      (user?.role === 'subscriber' && user.subscriptionStatus !== 'active')
+    ) {
       return null;
     }
 


### PR DESCRIPTION
## Summary
- add helper middleware to validate active subscriptions for authenticated subscribers
- guard offers, RFQs and market data routes with subscriber and subscription checks
- redirect inactive subscribers to `/pricing` on protected pages
- expose `subscriptionStatus` in auth responses for frontend use

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*
- `cd ../frontend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689dd31e1df48325967240a70965e021