### PR TITLE
feat: add market data model and refresh service

### DIFF
--- a/backend/controllers/marketData.js
+++ b/backend/controllers/marketData.js
@@ -1,44 +1,14 @@
-const fs = require('fs').promises;
-const path = require('path');
-
-const dataFile = path.join(__dirname, '..', 'data', 'marketData.json');
-
-async function loadData() {
-  const raw = await fs.readFile(dataFile, 'utf8');
-  return JSON.parse(raw);
-}
-
-async function saveData(data) {
-  await fs.writeFile(dataFile, JSON.stringify(data, null, 2));
-}
-
-function movingAverageForecast(data, window = 3, periods = 3) {
-  if (data.length < window) return [];
-  const prices = data.map((d) => d.price);
-  const avg = prices.slice(-window).reduce((a, b) => a + b, 0) / window;
-  const lastDate = new Date(data[data.length - 1].date);
-  const forecast = [];
-  for (let i = 1; i <= periods; i += 1) {
-    const next = new Date(lastDate);
-    next.setMonth(next.getMonth() + i);
-    forecast.push({
-      date: next.toISOString().split('T')[0],
-      price: parseFloat(avg.toFixed(2)),
-    });
-  }
-  return forecast;
-}
+const { MarketData } = require('../models');
+const { movingAverageForecast } = require('../utils/forecast');
 
 async function getMarketData(req, res) {
   try {
     const { commodity } = req.params;
-    const data = await loadData();
-    const historical = data[commodity];
-    if (!historical) {
+    const record = await MarketData.findOne({ where: { commodity } });
+    if (!record) {
       return res.status(404).json({ message: 'Commodity not found' });
     }
-    const forecast = movingAverageForecast(historical);
-    return res.json({ historical, forecast });
+    return res.json({ historical: record.historical, forecast: record.forecast });
   } catch (err) {
     return res.status(500).json({ message: 'Error loading market data' });
   }
@@ -48,12 +18,18 @@ async function addMarketData(req, res) {
   try {
     const { commodity } = req.params;
     const newEntry = req.body;
-    const data = await loadData();
-    if (!data[commodity]) {
-      data[commodity] = [];
+    let record = await MarketData.findOne({ where: { commodity } });
+    if (!record) {
+      const historical = [newEntry];
+      const forecast = movingAverageForecast(historical);
+      await MarketData.create({ commodity, historical, forecast });
+    } else {
+      const historical = record.historical || [];
+      historical.push(newEntry);
+      record.historical = historical;
+      record.forecast = movingAverageForecast(historical);
+      await record.save();
     }
-    data[commodity].push(newEntry);
-    await saveData(data);
     return res.status(201).json({ message: 'Data added' });
   } catch (err) {
     return res.status(500).json({ message: 'Error saving market data' });
@@ -64,9 +40,15 @@ async function updateMarketData(req, res) {
   try {
     const { commodity } = req.params;
     const { historical } = req.body;
-    const data = await loadData();
-    data[commodity] = historical;
-    await saveData(data);
+    let record = await MarketData.findOne({ where: { commodity } });
+    const forecast = movingAverageForecast(historical);
+    if (!record) {
+      await MarketData.create({ commodity, historical, forecast });
+    } else {
+      record.historical = historical;
+      record.forecast = forecast;
+      await record.save();
+    }
     return res.json({ message: 'Data updated' });
   } catch (err) {
     return res.status(500).json({ message: 'Error updating market data' });

--- a/backend/models/MarketData.js
+++ b/backend/models/MarketData.js
@@ -3,9 +3,9 @@ const { DataTypes } = require('sequelize');
 module.exports = (sequelize) => {
   const MarketData = sequelize.define('MarketData', {
     id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-    symbol: { type: DataTypes.STRING, allowNull: false },
-    bid: { type: DataTypes.FLOAT, allowNull: false },
-    ask: { type: DataTypes.FLOAT, allowNull: false },
+    commodity: { type: DataTypes.STRING, allowNull: false, unique: true },
+    historical: { type: DataTypes.JSON, allowNull: false, defaultValue: [] },
+    forecast: { type: DataTypes.JSON, allowNull: false, defaultValue: [] },
   });
   return MarketData;
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const { sequelize, WatchlistItem, NewsItem } = require('./models');
+const { scheduleMarketDataRefresh } = require('./services/marketDataService');
 
 const authRoutes = require('./routes/auth');
 const offerRoutes = require('./routes/offers');
@@ -59,4 +60,5 @@ sequelize.sync().then(async () => {
     ]);
   }
   app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  scheduleMarketDataRefresh();
 });

--- a/backend/services/marketDataService.js
+++ b/backend/services/marketDataService.js
@@ -1,0 +1,36 @@
+const { MarketData } = require('../models');
+const { movingAverageForecast } = require('../utils/forecast');
+
+async function fetchGoldPrice() {
+  const response = await fetch('https://api.coingecko.com/api/v3/coins/pax-gold');
+  const data = await response.json();
+  const price = data.market_data.current_price.usd;
+  return { date: new Date().toISOString().split('T')[0], price };
+}
+
+async function refreshGoldData() {
+  try {
+    const entry = await fetchGoldPrice();
+    let record = await MarketData.findOne({ where: { commodity: 'gold' } });
+    if (!record) {
+      const forecast = movingAverageForecast([entry]);
+      await MarketData.create({ commodity: 'gold', historical: [entry], forecast });
+    } else {
+      const historical = record.historical || [];
+      historical.push(entry);
+      record.historical = historical;
+      record.forecast = movingAverageForecast(historical);
+      await record.save();
+    }
+  } catch (err) {
+    console.error('Failed to refresh market data', err);
+  }
+}
+
+function scheduleMarketDataRefresh() {
+  refreshGoldData();
+  const sixHours = 6 * 60 * 60 * 1000;
+  setInterval(refreshGoldData, sixHours);
+}
+
+module.exports = { refreshGoldData, scheduleMarketDataRefresh };

--- a/backend/utils/forecast.js
+++ b/backend/utils/forecast.js
@@ -1,0 +1,18 @@
+function movingAverageForecast(data, window = 3, periods = 3) {
+  if (!Array.isArray(data) || data.length < window) return [];
+  const prices = data.map((d) => d.price);
+  const avg = prices.slice(-window).reduce((a, b) => a + b, 0) / window;
+  const lastDate = new Date(data[data.length - 1].date);
+  const forecast = [];
+  for (let i = 1; i <= periods; i += 1) {
+    const next = new Date(lastDate);
+    next.setMonth(next.getMonth() + i);
+    forecast.push({
+      date: next.toISOString().split('T')[0],
+      price: parseFloat(avg.toFixed(2)),
+    });
+  }
+  return forecast;
+}
+
+module.exports = { movingAverageForecast };


### PR DESCRIPTION
## Summary
- add MarketData model with historical and forecast JSON fields
- update market data controller to use Sequelize and support admin updates
- schedule periodic gold price refresh from public API

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dd43f353c83259ab864de089ab552