### PR TITLE
Add migrations and seed data for core backend tables

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,17 @@
 # FalconTrade Backend
 
 Express backend for FalconTrade platform.
+
+## Database
+
+Run migrations to create database tables:
+
+```bash
+npm run migrate
+```
+
+Populate the database with sample data:
+
+```bash
+npm run seed
+```

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -1,0 +1,16 @@
+require('dotenv').config();
+
+module.exports = {
+  development: {
+    url: process.env.DATABASE_URL,
+    dialect: 'postgres',
+  },
+  test: {
+    url: process.env.DATABASE_URL,
+    dialect: 'postgres',
+  },
+  production: {
+    url: process.env.DATABASE_URL,
+    dialect: 'postgres',
+  },
+};

--- a/backend/migrations/20240901000000-create-users.js
+++ b/backend/migrations/20240901000000-create-users.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Users', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      username: { type: Sequelize.STRING, allowNull: false, unique: true },
+      password: { type: Sequelize.STRING, allowNull: false },
+      role: { type: Sequelize.STRING, allowNull: false },
+      subscriptionStatus: { type: Sequelize.STRING, defaultValue: 'inactive' },
+      verificationToken: { type: Sequelize.STRING },
+      resetToken: { type: Sequelize.STRING },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('Users');
+  },
+};

--- a/backend/migrations/20240901000001-create-offers.js
+++ b/backend/migrations/20240901000001-create-offers.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Offers', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      symbol: { type: Sequelize.STRING, allowNull: false },
+      price: { type: Sequelize.FLOAT, allowNull: false },
+      quantity: { type: Sequelize.INTEGER, allowNull: false },
+      status: {
+        type: Sequelize.ENUM('pending', 'approved', 'featured'),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('Offers');
+  },
+};

--- a/backend/migrations/20240901000002-create-rfqs.js
+++ b/backend/migrations/20240901000002-create-rfqs.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('RFQs', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      symbol: { type: Sequelize.STRING, allowNull: false },
+      quantity: { type: Sequelize.INTEGER, allowNull: false },
+      status: {
+        type: Sequelize.ENUM('pending', 'approved', 'featured'),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('RFQs');
+  },
+};

--- a/backend/migrations/20240901000003-create-marketdata.js
+++ b/backend/migrations/20240901000003-create-marketdata.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('MarketData', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      commodity: { type: Sequelize.STRING, allowNull: false, unique: true },
+      historical: { type: Sequelize.JSON, allowNull: false, defaultValue: [] },
+      forecast: { type: Sequelize.JSON, allowNull: false, defaultValue: [] },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('MarketData');
+  },
+};

--- a/backend/migrations/20240901000004-create-messages.js
+++ b/backend/migrations/20240901000004-create-messages.js
@@ -1,0 +1,44 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Messages', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      fromUserId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      toUserId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      content: { type: Sequelize.TEXT, allowNull: false },
+      offerId: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'Offers', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      rfqId: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: { model: 'RFQs', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('Messages');
+  },
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,8 +11,10 @@
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.9.13",
         "pg": "^8.16.3",
         "pg-hstore": "^2.3.4",
         "sequelize": "^6.37.7",
@@ -802,6 +804,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dottie": {
@@ -2165,6 +2179,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nopt": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^6.9.13",

--- a/backend/seeders/20240901000005-demo-users.js
+++ b/backend/seeders/20240901000005-demo-users.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const bcrypt = require('bcrypt');
+
+module.exports = {
+  async up(queryInterface) {
+    const password1 = await bcrypt.hash('password123', 10);
+    const password2 = await bcrypt.hash('securepassword', 10);
+    await queryInterface.bulkInsert('Users', [
+      {
+        username: 'alice',
+        password: password1,
+        role: 'trader',
+        subscriptionStatus: 'active',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        username: 'bob',
+        password: password2,
+        role: 'broker',
+        subscriptionStatus: 'inactive',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('Users', { username: ['alice', 'bob'] });
+  },
+};

--- a/backend/seeders/20240901000006-demo-offers.js
+++ b/backend/seeders/20240901000006-demo-offers.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.bulkInsert('Offers', [
+      {
+        userId: 1,
+        symbol: 'GOLD',
+        price: 1900,
+        quantity: 10,
+        status: 'approved',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        userId: 2,
+        symbol: 'SILVER',
+        price: 25,
+        quantity: 100,
+        status: 'pending',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('Offers', null, {});
+  },
+};


### PR DESCRIPTION
## Summary
- add Sequelize config and migrations for Users, Offers, RFQs, MarketData, and Messages
- seed sample users and commodity offers
- document running `npm run migrate` and `npm run seed`

## Testing
- `npm run migrate` *(fails: ERROR)*
- `npm run seed` *(fails: ERROR)*

------
https://chatgpt.com/codex/tasks/task_e_689dd5a80bc88325ac7ee2bd4a052402