### PR TITLE
Block login for unverified accounts

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -56,6 +56,9 @@ router.post('/login', async (req, res) => {
     if (!user || !(await user.validatePassword(password))) {
       return res.status(401).json({ message: 'Invalid credentials' });
     }
+    if (user.verificationToken) {
+      return res.status(403).json({ message: 'Please verify your email' });
+    }
     const token = jwt.sign(
       { id: user.id, role: user.role },
       process.env.JWT_SECRET || 'secret',

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -20,7 +20,11 @@ export default function Login() {
       login(res.data);
       router.push('/');
     } catch (err) {
-      alert('Login failed');
+      if (err.response && err.response.status === 403) {
+        alert(err.response.data.message);
+      } else {
+        alert('Login failed');
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- return 403 during login when user has a pending email verification
- show "Please verify your email" message on login page for 403 responses

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689de9dccedc8325946ce5156b8aa958