### PR TITLE
Use cookie-based auth across app

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -4,11 +4,15 @@ const { User } = require('../models');
 // Middleware to verify JWT tokens and attach the user to the request
 async function auth(req, res, next) {
   const authHeader = req.headers['authorization'];
-  if (!authHeader) {
+  let token;
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    token = authHeader.split(' ')[1];
+  } else {
+    token = req.cookies.token;
+  }
+  if (!token) {
     return res.status(401).json({ message: 'No token provided' });
   }
-
-  const token = authHeader.split(' ')[1];
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
     const user = await User.findByPk(decoded.id);

--- a/frontend/components/withAuth.js
+++ b/frontend/components/withAuth.js
@@ -4,26 +4,28 @@ import { useAuth } from '../contexts/AuthContext';
 
 export default function withAuth(Component, requiredRole) {
   return function Protected(props) {
-    const { token, user } = useAuth();
+    const { user, loading } = useAuth();
     const router = useRouter();
 
     useEffect(() => {
-      if (!token) {
+      if (loading) return;
+      if (!user) {
         router.replace('/login');
-      } else if (requiredRole && user?.role !== requiredRole) {
+      } else if (requiredRole && user.role !== requiredRole) {
         router.replace('/');
       } else if (
-        user?.role === 'subscriber' &&
+        user.role === 'subscriber' &&
         user.subscriptionStatus !== 'active'
       ) {
         router.replace('/pricing');
       }
-    }, [token, user, router]);
+    }, [user, loading, router]);
 
     if (
-      !token ||
-      (requiredRole && user?.role !== requiredRole) ||
-      (user?.role === 'subscriber' && user.subscriptionStatus !== 'active')
+      loading ||
+      !user ||
+      (requiredRole && user.role !== requiredRole) ||
+      (user.role === 'subscriber' && user.subscriptionStatus !== 'active')
     ) {
       return null;
     }

--- a/frontend/contexts/AuthContext.js
+++ b/frontend/contexts/AuthContext.js
@@ -3,8 +3,8 @@ import { createContext, useContext, useState, useEffect } from 'react';
 const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
-  const [token, setToken] = useState(null);
   const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -15,10 +15,11 @@ export function AuthProvider({ children }) {
         if (res.ok) {
           const data = await res.json();
           setUser(data);
-          setToken(true);
         }
       } catch (err) {
         console.error(err);
+      } finally {
+        setLoading(false);
       }
     };
     fetchUser();
@@ -26,16 +27,14 @@ export function AuthProvider({ children }) {
 
   const login = (userData) => {
     setUser(userData);
-    setToken(true);
   };
 
   const logout = () => {
     setUser(null);
-    setToken(null);
   };
 
   return (
-    <AuthContext.Provider value={{ token, user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, logout, loading }}>
       {children}
     </AuthContext.Provider>
   );
@@ -44,3 +43,4 @@ export function AuthProvider({ children }) {
 export function useAuth() {
   return useContext(AuthContext);
 }
+

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -4,11 +4,11 @@ import ThemeToggle from '../components/ThemeToggle';
 import PublicNav from '../components/PublicNav';
 
 function AppContent({ Component, pageProps }) {
-  const { token } = useAuth();
+  const { user } = useAuth();
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 text-black dark:text-white">
       <ThemeToggle />
-      {!token && <PublicNav />}
+      {!user && <PublicNav />}
       <Component {...pageProps} />
     </div>
   );

--- a/frontend/pages/admin.js
+++ b/frontend/pages/admin.js
@@ -4,24 +4,24 @@ import { useAuth } from '../contexts/AuthContext';
 import withAuth from '../components/withAuth';
 
 function Admin() {
-  const { token } = useAuth();
+  const { user } = useAuth();
   const [metrics, setMetrics] = useState(null);
 
   useEffect(() => {
     const fetchMetrics = async () => {
       try {
         const res = await axios.get('http://localhost:5000/api/v1/admin/metrics', {
-          headers: { Authorization: `Bearer ${token}` },
+          withCredentials: true,
         });
         setMetrics(res.data);
       } catch (err) {
         console.error(err);
       }
     };
-    if (token) {
+    if (user) {
       fetchMetrics();
     }
-  }, [token]);
+  }, [user]);
 
   if (!metrics) return <p>Loading...</p>;
 

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -13,29 +13,30 @@ import {
 import withAuth from '../components/withAuth';
 
 function Dashboard() {
-  const { token } = useAuth();
+  const { user } = useAuth();
   const [watchlist, setWatchlist] = useState([]);
   const [news, setNews] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const watchlistRes = await axios.get('http://localhost:5000/api/v1/watchlist', {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const watchlistRes = await axios.get(
+          'http://localhost:5000/api/v1/watchlist',
+          { withCredentials: true }
+        );
         setWatchlist(watchlistRes.data);
         const newsRes = await axios.get('http://localhost:5000/api/v1/news', {
-          headers: { Authorization: `Bearer ${token}` },
+          withCredentials: true,
         });
         setNews(newsRes.data);
       } catch (err) {
         console.error(err);
       }
     };
-    if (token) {
+    if (user) {
       fetchData();
     }
-  }, [token]);
+  }, [user]);
 
   return (
     <div className="p-4">

--- a/frontend/pages/messages.js
+++ b/frontend/pages/messages.js
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import withAuth from '../components/withAuth';
 
 function Messages() {
-  const { token } = useAuth();
+  const { user } = useAuth();
   const [messages, setMessages] = useState([]);
   const [toUserId, setToUserId] = useState('');
   const [content, setContent] = useState('');
@@ -13,7 +13,7 @@ function Messages() {
   const fetchMessages = async () => {
     try {
       const res = await axios.get('http://localhost:5000/api/v1/messages', {
-        headers: { Authorization: `Bearer ${token}` },
+        withCredentials: true,
       });
       setMessages(res.data);
     } catch (err) {
@@ -22,10 +22,10 @@ function Messages() {
   };
 
   useEffect(() => {
-    if (token) {
+    if (user) {
       fetchMessages();
     }
-  }, [token]);
+  }, [user]);
 
   const handleFileChange = (e) => {
     setFiles(Array.from(e.target.files));
@@ -39,8 +39,8 @@ function Messages() {
       formData.append('content', content);
       files.forEach((file) => formData.append('attachments', file));
       await axios.post('http://localhost:5000/api/v1/messages', formData, {
+        withCredentials: true,
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'multipart/form-data',
         },
       });


### PR DESCRIPTION
## Summary
- Allow backend auth middleware to read JWTs from cookies when Authorization header missing
- Drop token flag from AuthContext and guard pages using user info
- Send cookies on frontend API calls instead of Authorization headers

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689df1a49c148325a1323ee69dc10d50