### PR TITLE
Add company profile fields and user profile page

### DIFF
--- a/backend/migrations/20240901000006-add-company-fields-to-users.js
+++ b/backend/migrations/20240901000006-add-company-fields-to-users.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Users', 'companyName', {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn('Users', 'companyWebsite', {
+      type: Sequelize.STRING,
+    });
+    await queryInterface.addColumn('Users', 'logoUrl', {
+      type: Sequelize.STRING,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Users', 'logoUrl');
+    await queryInterface.removeColumn('Users', 'companyWebsite');
+    await queryInterface.removeColumn('Users', 'companyName');
+  },
+};

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -12,6 +12,9 @@ module.exports = (sequelize) => {
       subscriptionStatus: { type: DataTypes.STRING, defaultValue: 'inactive' },
       verificationToken: { type: DataTypes.STRING },
       resetToken: { type: DataTypes.STRING },
+      companyName: { type: DataTypes.STRING },
+      companyWebsite: { type: DataTypes.STRING },
+      logoUrl: { type: DataTypes.STRING },
     },
     {
       hooks: {

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const path = require('path');
+const multer = require('multer');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (req, file, cb) => {
+      cb(null, path.join(__dirname, '..', 'uploads'));
+    },
+    filename: (req, file, cb) => {
+      cb(null, Date.now() + '-' + file.originalname);
+    },
+  }),
+});
+
+function sanitize(user) {
+  const data = user.toJSON();
+  delete data.password;
+  delete data.resetToken;
+  delete data.verificationToken;
+  return data;
+}
+
+router.get('/me', auth, async (req, res) => {
+  res.json(sanitize(req.user));
+});
+
+router.put('/me', auth, upload.single('logo'), async (req, res) => {
+  try {
+    const { companyName, companyWebsite } = req.body;
+    if (companyName !== undefined) {
+      req.user.companyName = companyName;
+    }
+    if (companyWebsite !== undefined) {
+      req.user.companyWebsite = companyWebsite;
+    }
+    if (req.file) {
+      req.user.logoUrl = `/uploads/${req.file.filename}`;
+    }
+    await req.user.save();
+    res.json(sanitize(req.user));
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,6 +14,7 @@ const paymentRoutes = require('./routes/payments');
 const watchlistRoutes = require('./routes/watchlist');
 const newsRoutes = require('./routes/news');
 const adminRoutes = require('./routes/admin');
+const userRoutes = require('./routes/users');
 const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
@@ -34,6 +35,7 @@ app.use('/api/v1/payments', paymentRoutes);
 app.use('/api/v1/watchlist', watchlistRoutes);
 app.use('/api/v1/news', newsRoutes);
 app.use('/api/v1/admin', adminRoutes);
+app.use('/api/v1/users', userRoutes);
 
 app.get('/', (req, res) => {
   res.send('FalconTrade Backend is running');

--- a/frontend/pages/profile.js
+++ b/frontend/pages/profile.js
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useAuth } from '../contexts/AuthContext';
+import withAuth from '../components/withAuth';
+
+function Profile() {
+  const { user } = useAuth();
+  const [companyName, setCompanyName] = useState('');
+  const [companyWebsite, setCompanyWebsite] = useState('');
+  const [logo, setLogo] = useState(null);
+  const [logoUrl, setLogoUrl] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    const fetchProfile = async () => {
+      try {
+        const res = await axios.get('http://localhost:5000/api/v1/users/me', {
+          withCredentials: true,
+        });
+        setCompanyName(res.data.companyName || '');
+        setCompanyWebsite(res.data.companyWebsite || '');
+        setLogoUrl(res.data.logoUrl || '');
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchProfile();
+  }, [user]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const formData = new FormData();
+      formData.append('companyName', companyName);
+      formData.append('companyWebsite', companyWebsite);
+      if (logo) {
+        formData.append('logo', logo);
+      }
+      const res = await axios.put(
+        'http://localhost:5000/api/v1/users/me',
+        formData,
+        {
+          withCredentials: true,
+          headers: { 'Content-Type': 'multipart/form-data' },
+        }
+      );
+      setLogoUrl(res.data.logoUrl || '');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Profile</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          className="border p-2 w-full"
+          placeholder="Company Name"
+          value={companyName}
+          onChange={(e) => setCompanyName(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Company Website"
+          value={companyWebsite}
+          onChange={(e) => setCompanyWebsite(e.target.value)}
+        />
+        {logoUrl && (
+          <img
+            src={`http://localhost:5000${logoUrl}`}
+            alt="Company Logo"
+            className="h-24"
+          />
+        )}
+        <input type="file" onChange={(e) => setLogo(e.target.files[0])} />
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Save
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default withAuth(Profile);


### PR DESCRIPTION
## Summary
- extend User model with company info fields and corresponding migration
- add /api/v1/users/me endpoints with Multer logo uploads
- create Next.js profile page for editing company details

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689df3c76c3883259bf1d512478a54f2