### PR TITLE
feat: expand commodity market data

### DIFF
--- a/backend/controllers/marketData.js
+++ b/backend/controllers/marketData.js
@@ -8,7 +8,12 @@ async function getMarketData(req, res) {
     if (!record) {
       return res.status(404).json({ message: 'Commodity not found' });
     }
-    return res.json({ historical: record.historical, forecast: record.forecast });
+    return res.json({
+      currentPrice: record.currentPrice,
+      changePercent: record.changePercent,
+      historical: record.historical,
+      forecast: record.forecast,
+    });
   } catch (err) {
     return res.status(500).json({ message: 'Error loading market data' });
   }
@@ -17,15 +22,19 @@ async function getMarketData(req, res) {
 async function addMarketData(req, res) {
   try {
     const { commodity } = req.params;
-    const newEntry = req.body;
+    const { currentPrice, changePercent, date } = req.body;
+    const entryDate = date || new Date().toISOString().split('T')[0];
+    const newEntry = { date: entryDate, price: currentPrice };
     let record = await MarketData.findOne({ where: { commodity } });
     if (!record) {
       const historical = [newEntry];
       const forecast = movingAverageForecast(historical);
-      await MarketData.create({ commodity, historical, forecast });
+      await MarketData.create({ commodity, currentPrice, changePercent, historical, forecast });
     } else {
       const historical = record.historical || [];
       historical.push(newEntry);
+      record.currentPrice = currentPrice;
+      record.changePercent = changePercent;
       record.historical = historical;
       record.forecast = movingAverageForecast(historical);
       await record.save();
@@ -39,12 +48,14 @@ async function addMarketData(req, res) {
 async function updateMarketData(req, res) {
   try {
     const { commodity } = req.params;
-    const { historical } = req.body;
+    const { historical, currentPrice, changePercent } = req.body;
     let record = await MarketData.findOne({ where: { commodity } });
     const forecast = movingAverageForecast(historical);
     if (!record) {
-      await MarketData.create({ commodity, historical, forecast });
+      await MarketData.create({ commodity, currentPrice, changePercent, historical, forecast });
     } else {
+      record.currentPrice = currentPrice;
+      record.changePercent = changePercent;
       record.historical = historical;
       record.forecast = forecast;
       await record.save();

--- a/backend/migrations/20240901000003-create-marketdata.js
+++ b/backend/migrations/20240901000003-create-marketdata.js
@@ -5,6 +5,8 @@ module.exports = {
     await queryInterface.createTable('MarketData', {
       id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
       commodity: { type: Sequelize.STRING, allowNull: false, unique: true },
+      currentPrice: { type: Sequelize.FLOAT, allowNull: true },
+      changePercent: { type: Sequelize.FLOAT, allowNull: true },
       historical: { type: Sequelize.JSON, allowNull: false, defaultValue: [] },
       forecast: { type: Sequelize.JSON, allowNull: false, defaultValue: [] },
       createdAt: { allowNull: false, type: Sequelize.DATE },

--- a/backend/models/MarketData.js
+++ b/backend/models/MarketData.js
@@ -4,6 +4,8 @@ module.exports = (sequelize) => {
   const MarketData = sequelize.define('MarketData', {
     id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
     commodity: { type: DataTypes.STRING, allowNull: false, unique: true },
+    currentPrice: { type: DataTypes.FLOAT, allowNull: true },
+    changePercent: { type: DataTypes.FLOAT, allowNull: true },
     historical: { type: DataTypes.JSON, allowNull: false, defaultValue: [] },
     forecast: { type: DataTypes.JSON, allowNull: false, defaultValue: [] },
   });

--- a/backend/services/marketDataService.js
+++ b/backend/services/marketDataService.js
@@ -1,26 +1,107 @@
 const { MarketData } = require('../models');
 const { movingAverageForecast } = require('../utils/forecast');
 
-async function fetchGoldPrice() {
-  const response = await fetch('https://api.coingecko.com/api/v3/coins/pax-gold');
-  const data = await response.json();
-  const price = data.market_data.current_price.usd;
-  return { date: new Date().toISOString().split('T')[0], price };
+const SOURCES = [
+  {
+    commodity: 'gold',
+    fetch: async () => {
+      const response = await fetch('https://data-asg.goldprice.org/dbXRates/USD');
+      const data = await response.json();
+      const item = data.items[0];
+      return {
+        currentPrice: item.xauPrice,
+        changePercent: item.pcXau,
+      };
+    },
+  },
+  {
+    commodity: 'silver',
+    fetch: async () => {
+      const response = await fetch('https://data-asg.goldprice.org/dbXRates/USD');
+      const data = await response.json();
+      const item = data.items[0];
+      return {
+        currentPrice: item.xagPrice,
+        changePercent: item.pcXag,
+      };
+    },
+  },
+  {
+    commodity: 'wti',
+    fetch: async () => {
+      const response = await fetch('https://www.alphavantage.co/query?function=WTI&interval=daily&apikey=demo');
+      const data = await response.json();
+      const series = data.data || data['data'];
+      if (!Array.isArray(series) || series.length < 2) throw new Error('No data');
+      const latest = series[0];
+      const prev = series[1];
+      const price = parseFloat(latest.value || latest.price || latest['1. open']);
+      const prevPrice = parseFloat(prev.value || prev.price || prev['1. open']);
+      const changePercent = ((price - prevPrice) / prevPrice) * 100;
+      return {
+        currentPrice: price,
+        changePercent,
+        date: latest.date || latest.timestamp || new Date().toISOString().split('T')[0],
+      };
+    },
+  },
+  {
+    commodity: 'corn',
+    fetch: async () => {
+      const response = await fetch('https://www.alphavantage.co/query?function=CORN&interval=daily&apikey=demo');
+      const data = await response.json();
+      const series = data.data || data['data'];
+      if (!Array.isArray(series) || series.length < 2) throw new Error('No data');
+      const latest = series[0];
+      const prev = series[1];
+      const price = parseFloat(latest.value || latest.price || latest['1. open']);
+      const prevPrice = parseFloat(prev.value || prev.price || prev['1. open']);
+      const changePercent = ((price - prevPrice) / prevPrice) * 100;
+      return {
+        currentPrice: price,
+        changePercent,
+        date: latest.date || latest.timestamp || new Date().toISOString().split('T')[0],
+      };
+    },
+  },
+];
+
+async function fetchCommodity(source) {
+  const result = await source.fetch();
+  const date = result.date || new Date().toISOString().split('T')[0];
+  return {
+    commodity: source.commodity,
+    currentPrice: result.currentPrice,
+    changePercent: result.changePercent,
+    entry: { date, price: result.currentPrice },
+  };
 }
 
-async function refreshGoldData() {
+async function refreshMarketData() {
   try {
-    const entry = await fetchGoldPrice();
-    let record = await MarketData.findOne({ where: { commodity: 'gold' } });
-    if (!record) {
-      const forecast = movingAverageForecast([entry]);
-      await MarketData.create({ commodity: 'gold', historical: [entry], forecast });
-    } else {
-      const historical = record.historical || [];
-      historical.push(entry);
-      record.historical = historical;
-      record.forecast = movingAverageForecast(historical);
-      await record.save();
+    const results = await Promise.allSettled(SOURCES.map(fetchCommodity));
+    const updates = results
+      .filter((r) => r.status === 'fulfilled')
+      .map((r) => r.value);
+
+    const existing = await MarketData.findAll();
+    const payload = updates.map((u) => {
+      const match = existing.find((e) => e.commodity === u.commodity);
+      const historical = match ? [...(match.historical || []), u.entry] : [u.entry];
+      const forecast = movingAverageForecast(historical);
+      return {
+        commodity: u.commodity,
+        currentPrice: u.currentPrice,
+        changePercent: u.changePercent,
+        historical,
+        forecast,
+      };
+    });
+
+    if (payload.length > 0) {
+      await MarketData.bulkCreate(payload, {
+        updateOnDuplicate: ['currentPrice', 'changePercent', 'historical', 'forecast'],
+      });
     }
   } catch (err) {
     console.error('Failed to refresh market data', err);
@@ -28,9 +109,9 @@ async function refreshGoldData() {
 }
 
 function scheduleMarketDataRefresh() {
-  refreshGoldData();
-  const sixHours = 6 * 60 * 60 * 1000;
-  setInterval(refreshGoldData, sixHours);
+  refreshMarketData();
+  const fifteenMinutes = 15 * 60 * 1000;
+  setInterval(refreshMarketData, fifteenMinutes);
 }
 
-module.exports = { refreshGoldData, scheduleMarketDataRefresh };
+module.exports = { refreshMarketData, scheduleMarketDataRefresh };


### PR DESCRIPTION
## Summary
- support gold, silver, oil and agriculture price pulls via free APIs
- track current price and daily change percent for each commodity
- refresh market data every 15 minutes and bulk update records

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689df54d776883259e231dc20211f9e2