### PR TITLE
Add forecasting service and dashboard visualization

### DIFF
--- a/backend/controllers/forecast.js
+++ b/backend/controllers/forecast.js
@@ -1,0 +1,16 @@
+const { getForecastForCommodity } = require('../services/forecasting');
+
+async function getForecast(req, res) {
+  try {
+    const { commodity } = req.params;
+    const data = await getForecastForCommodity(commodity);
+    if (!data) {
+      return res.status(404).json({ message: 'Commodity not found' });
+    }
+    return res.json(data);
+  } catch (err) {
+    return res.status(500).json({ message: 'Error generating forecast' });
+  }
+}
+
+module.exports = { getForecast };

--- a/backend/routes/forecast.js
+++ b/backend/routes/forecast.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const { isSubscriber } = require('../middleware/roles');
+const forecastController = require('../controllers/forecast');
+
+const router = express.Router();
+
+router.get(
+  '/:commodity',
+  auth,
+  isSubscriber,
+  auth.requireActiveSubscription,
+  forecastController.getForecast
+);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,7 @@ const watchlistRoutes = require('./routes/watchlist');
 const newsRoutes = require('./routes/news');
 const adminRoutes = require('./routes/admin');
 const userRoutes = require('./routes/users');
+const forecastRoutes = require('./routes/forecast');
 const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
@@ -30,6 +31,7 @@ app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/offers', offerRoutes);
 app.use('/api/v1/rfqs', rfqRoutes);
 app.use('/api/v1/market-data', marketDataRoutes);
+app.use('/api/v1/forecast', forecastRoutes);
 app.use('/api/v1/messages', messageRoutes);
 app.use('/api/v1/payments', paymentRoutes);
 app.use('/api/v1/watchlist', watchlistRoutes);

--- a/backend/services/forecasting.js
+++ b/backend/services/forecasting.js
@@ -1,0 +1,51 @@
+const { MarketData } = require('../models');
+let tf;
+try {
+  tf = require('@tensorflow/tfjs');
+} catch (err) {
+  tf = null;
+  console.warn('TensorFlow.js not installed, using stub forecast');
+}
+
+function forecastFromHistorical(historical, periods = 3) {
+  if (!Array.isArray(historical) || historical.length === 0) return [];
+  const prices = historical.map((h) => h.price);
+  let predicted = [];
+  if (tf) {
+    try {
+      const xs = tf.tensor1d(prices.map((_, i) => i));
+      const ys = tf.tensor1d(prices);
+      const xMean = xs.mean();
+      const yMean = ys.mean();
+      const numerator = xs.sub(xMean).mul(ys.sub(yMean)).sum();
+      const denominator = xs.sub(xMean).square().sum();
+      const slope = numerator.div(denominator).dataSync()[0];
+      const intercept = yMean.sub(xMean.mul(slope)).dataSync()[0];
+      const lastIndex = prices.length - 1;
+      predicted = Array.from({ length: periods }, (_, i) => intercept + slope * (lastIndex + i + 1));
+    } catch (e) {
+      predicted = [];
+    }
+  }
+  if (predicted.length === 0) {
+    const last = prices[prices.length - 1];
+    const prev = prices[prices.length - 2] || last;
+    const diff = last - prev;
+    predicted = Array.from({ length: periods }, (_, i) => last + diff * (i + 1));
+  }
+  const lastDate = new Date(historical[historical.length - 1].date);
+  return predicted.map((p, idx) => {
+    const d = new Date(lastDate);
+    d.setMonth(d.getMonth() + idx + 1);
+    return { date: d.toISOString().split('T')[0], price: parseFloat(p.toFixed(2)) };
+  });
+}
+
+async function getForecastForCommodity(commodity, periods = 3) {
+  const record = await MarketData.findOne({ where: { commodity } });
+  if (!record) return null;
+  const forecast = forecastFromHistorical(record.historical, periods);
+  return { historical: record.historical, forecast };
+}
+
+module.exports = { forecastFromHistorical, getForecastForCommodity };

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -16,6 +16,7 @@ function Dashboard() {
   const { user } = useAuth();
   const [watchlist, setWatchlist] = useState([]);
   const [news, setNews] = useState([]);
+  const [forecastData, setForecastData] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -29,6 +30,19 @@ function Dashboard() {
           withCredentials: true,
         });
         setNews(newsRes.data);
+        const forecastRes = await axios.get(
+          'http://localhost:5000/api/v1/forecast/gold',
+          { withCredentials: true }
+        );
+        const { historical = [], forecast = [] } = forecastRes.data;
+        const combined = historical.map((h) => ({
+          date: h.date,
+          historical: h.price,
+        }));
+        forecast.forEach((f) => {
+          combined.push({ date: f.date, forecast: f.price });
+        });
+        setForecastData(combined);
       } catch (err) {
         console.error(err);
       }
@@ -49,6 +63,19 @@ function Dashboard() {
             <YAxis />
             <Tooltip />
             <Line type="monotone" dataKey="price" stroke="#8884d8" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      <h1 className="text-2xl mt-8 mb-4">Gold Price Forecast</h1>
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <LineChart data={forecastData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="historical" stroke="#8884d8" name="Historical" />
+            <Line type="monotone" dataKey="forecast" stroke="#82ca9d" name="Forecast" />
           </LineChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
## Summary
- implement forecasting service with TensorFlow.js fallback
- expose `/api/v1/forecast/:commodity` endpoint
- display historical vs forecast data on dashboard

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689df6c78c2883258f7955ce52db6b40