### PR TITLE
Add filtering and upload support for offers and RFQs with UI

### DIFF
--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -1,29 +1,67 @@
 const express = require('express');
+const path = require('path');
+const multer = require('multer');
 const auth = require('../middleware/auth');
 const { isAdmin, isSubscriber } = require('../middleware/roles');
 const { Offer } = require('../models');
 
 const router = express.Router();
 
-// Create a new offer
-router.post('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
-  try {
-    const { symbol, price, quantity } = req.body;
-    const offer = await Offer.create({
-      userId: req.user.id,
-      symbol,
-      price,
-      quantity,
-    });
-    res.json(offer);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (req, file, cb) => {
+      cb(null, path.join(__dirname, '..', 'uploads'));
+    },
+    filename: (req, file, cb) => {
+      cb(null, Date.now() + '-' + file.originalname);
+    },
+  }),
 });
+
+// Create a new offer
+router.post(
+  '/',
+  auth,
+  isSubscriber,
+  auth.requireActiveSubscription,
+  upload.array('attachments'),
+  async (req, res) => {
+    try {
+      const { symbol, price, quantity } = req.body;
+      const offer = await Offer.create({
+        userId: req.user.id,
+        symbol,
+        price,
+        quantity,
+      });
+      const attachments = (req.files || []).map((file) => ({
+        filename: file.filename,
+        url: `/uploads/${file.filename}`,
+        mimetype: file.mimetype,
+        size: file.size,
+      }));
+      const result = offer.toJSON();
+      result.attachments = attachments;
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  }
+);
 
 // Get all offers
 router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
-  const offers = await Offer.findAll();
+  const { commodity, status, sortBy, order } = req.query;
+  const where = {};
+  if (commodity) where.symbol = commodity;
+  if (status) where.status = status;
+  const options = { where };
+  if (sortBy) {
+    options.order = [
+      [sortBy, order && order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC'],
+    ];
+  }
+  const offers = await Offer.findAll(options);
   res.json(offers);
 });
 

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -1,28 +1,66 @@
 const express = require('express');
+const path = require('path');
+const multer = require('multer');
 const auth = require('../middleware/auth');
 const { isAdmin, isSubscriber } = require('../middleware/roles');
 const { RFQ } = require('../models');
 
 const router = express.Router();
 
-// Create a new RFQ
-router.post('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
-  try {
-    const { symbol, quantity } = req.body;
-    const rfq = await RFQ.create({
-      userId: req.user.id,
-      symbol,
-      quantity,
-    });
-    res.json(rfq);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (req, file, cb) => {
+      cb(null, path.join(__dirname, '..', 'uploads'));
+    },
+    filename: (req, file, cb) => {
+      cb(null, Date.now() + '-' + file.originalname);
+    },
+  }),
 });
+
+// Create a new RFQ
+router.post(
+  '/',
+  auth,
+  isSubscriber,
+  auth.requireActiveSubscription,
+  upload.array('attachments'),
+  async (req, res) => {
+    try {
+      const { symbol, quantity } = req.body;
+      const rfq = await RFQ.create({
+        userId: req.user.id,
+        symbol,
+        quantity,
+      });
+      const attachments = (req.files || []).map((file) => ({
+        filename: file.filename,
+        url: `/uploads/${file.filename}`,
+        mimetype: file.mimetype,
+        size: file.size,
+      }));
+      const result = rfq.toJSON();
+      result.attachments = attachments;
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  }
+);
 
 // Get all RFQs
 router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
-  const rfqs = await RFQ.findAll();
+  const { commodity, status, sortBy, order } = req.query;
+  const where = {};
+  if (commodity) where.symbol = commodity;
+  if (status) where.status = status;
+  const options = { where };
+  if (sortBy) {
+    options.order = [
+      [sortBy, order && order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC'],
+    ];
+  }
+  const rfqs = await RFQ.findAll(options);
   res.json(rfqs);
 });
 

--- a/frontend/pages/offers/index.js
+++ b/frontend/pages/offers/index.js
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import Link from 'next/link';
+import withAuth from '../../components/withAuth';
+
+function Offers() {
+  const [offers, setOffers] = useState([]);
+  const [commodity, setCommodity] = useState('');
+  const [status, setStatus] = useState('');
+  const [sortBy, setSortBy] = useState('');
+  const [order, setOrder] = useState('ASC');
+
+  const fetchOffers = async () => {
+    try {
+      const params = {};
+      if (commodity) params.commodity = commodity;
+      if (status) params.status = status;
+      if (sortBy) {
+        params.sortBy = sortBy;
+        params.order = order;
+      }
+      const res = await axios.get('http://localhost:5000/api/v1/offers', {
+        params,
+        withCredentials: true,
+      });
+      setOffers(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchOffers();
+  }, []);
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    fetchOffers();
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Offers</h1>
+      <form onSubmit={handleSearch} className="space-y-2 mb-4">
+        <input
+          className="border p-2 w-full"
+          placeholder="Commodity"
+          value={commodity}
+          onChange={(e) => setCommodity(e.target.value)}
+        />
+        <select
+          className="border p-2 w-full"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="featured">Featured</option>
+        </select>
+        <div className="flex space-x-2">
+          <select
+            className="border p-2 w-full"
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value)}
+          >
+            <option value="">No Sort</option>
+            <option value="price">Price</option>
+            <option value="quantity">Quantity</option>
+            <option value="createdAt">Created At</option>
+          </select>
+          <select
+            className="border p-2 w-full"
+            value={order}
+            onChange={(e) => setOrder(e.target.value)}
+          >
+            <option value="ASC">Asc</option>
+            <option value="DESC">Desc</option>
+          </select>
+        </div>
+        <div>
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-4 py-2 mr-2"
+          >
+            Search
+          </button>
+          <Link
+            href="/offers/new"
+            className="bg-green-500 text-white px-4 py-2"
+          >
+            New Offer
+          </Link>
+        </div>
+      </form>
+      <ul>
+        {offers.map((offer) => (
+          <li key={offer.id} className="border p-2 mb-2">
+            {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(Offers);
+

--- a/frontend/pages/offers/new.js
+++ b/frontend/pages/offers/new.js
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import withAuth from '../../components/withAuth';
+
+function NewOffer() {
+  const router = useRouter();
+  const [symbol, setSymbol] = useState('');
+  const [price, setPrice] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [files, setFiles] = useState([]);
+
+  const handleFileChange = (e) => {
+    setFiles(Array.from(e.target.files));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const formData = new FormData();
+      formData.append('symbol', symbol);
+      formData.append('price', price);
+      formData.append('quantity', quantity);
+      files.forEach((file) => formData.append('attachments', file));
+      await axios.post('http://localhost:5000/api/v1/offers', formData, {
+        withCredentials: true,
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      router.push('/offers');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">New Offer</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Commodity"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Price"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+        />
+        <input type="file" multiple onChange={handleFileChange} />
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Create
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default withAuth(NewOffer);
+

--- a/frontend/pages/rfqs/index.js
+++ b/frontend/pages/rfqs/index.js
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import Link from 'next/link';
+import withAuth from '../../components/withAuth';
+
+function RFQs() {
+  const [rfqs, setRfqs] = useState([]);
+  const [commodity, setCommodity] = useState('');
+  const [status, setStatus] = useState('');
+  const [sortBy, setSortBy] = useState('');
+  const [order, setOrder] = useState('ASC');
+
+  const fetchRfqs = async () => {
+    try {
+      const params = {};
+      if (commodity) params.commodity = commodity;
+      if (status) params.status = status;
+      if (sortBy) {
+        params.sortBy = sortBy;
+        params.order = order;
+      }
+      const res = await axios.get('http://localhost:5000/api/v1/rfqs', {
+        params,
+        withCredentials: true,
+      });
+      setRfqs(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchRfqs();
+  }, []);
+
+  const handleSearch = (e) => {
+    e.preventDefault();
+    fetchRfqs();
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">RFQs</h1>
+      <form onSubmit={handleSearch} className="space-y-2 mb-4">
+        <input
+          className="border p-2 w-full"
+          placeholder="Commodity"
+          value={commodity}
+          onChange={(e) => setCommodity(e.target.value)}
+        />
+        <select
+          className="border p-2 w-full"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="featured">Featured</option>
+        </select>
+        <div className="flex space-x-2">
+          <select
+            className="border p-2 w-full"
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value)}
+          >
+            <option value="">No Sort</option>
+            <option value="quantity">Quantity</option>
+            <option value="createdAt">Created At</option>
+          </select>
+          <select
+            className="border p-2 w-full"
+            value={order}
+            onChange={(e) => setOrder(e.target.value)}
+          >
+            <option value="ASC">Asc</option>
+            <option value="DESC">Desc</option>
+          </select>
+        </div>
+        <div>
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-4 py-2 mr-2"
+          >
+            Search
+          </button>
+          <Link
+            href="/rfqs/new"
+            className="bg-green-500 text-white px-4 py-2"
+          >
+            New RFQ
+          </Link>
+        </div>
+      </form>
+      <ul>
+        {rfqs.map((rfq) => (
+          <li key={rfq.id} className="border p-2 mb-2">
+            {rfq.symbol} - {rfq.quantity} - {rfq.status}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(RFQs);
+

--- a/frontend/pages/rfqs/new.js
+++ b/frontend/pages/rfqs/new.js
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import withAuth from '../../components/withAuth';
+
+function NewRFQ() {
+  const router = useRouter();
+  const [symbol, setSymbol] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [files, setFiles] = useState([]);
+
+  const handleFileChange = (e) => {
+    setFiles(Array.from(e.target.files));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const formData = new FormData();
+      formData.append('symbol', symbol);
+      formData.append('quantity', quantity);
+      files.forEach((file) => formData.append('attachments', file));
+      await axios.post('http://localhost:5000/api/v1/rfqs', formData, {
+        withCredentials: true,
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      router.push('/rfqs');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">New RFQ</h1>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="border p-2 w-full"
+          placeholder="Commodity"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+        />
+        <input type="file" multiple onChange={handleFileChange} />
+        <button className="bg-blue-500 text-white px-4 py-2" type="submit">
+          Create
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default withAuth(NewRFQ);
+


### PR DESCRIPTION
## Summary
- allow offers and RFQs to filter by commodity, status, and sorting
- support file uploads on offer/RFQ creation
- add frontend pages for offers and RFQs with search/filter and create forms

## Testing
- `cd backend && npm test` (fails: Missing script: "test")
- `cd frontend && npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_689e04c0883c8325bb294d3a96e73585