### PR TITLE
feat: add admin management endpoints and pages

### DIFF
--- a/backend/models/RFQ.js
+++ b/backend/models/RFQ.js
@@ -7,7 +7,7 @@ module.exports = (sequelize) => {
     symbol: { type: DataTypes.STRING, allowNull: false },
     quantity: { type: DataTypes.INTEGER, allowNull: false },
     status: {
-      type: DataTypes.ENUM('pending', 'approved', 'featured'),
+      type: DataTypes.ENUM('pending', 'approved', 'featured', 'rejected'),
       allowNull: false,
       defaultValue: 'pending',
     },

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -4,20 +4,30 @@ const { isAdmin } = require('../middleware/roles');
 const {
   getMetrics,
   getUsers,
+  updateUser,
   deleteUser,
   getListings,
   approveListing,
   deleteListing,
+  getRFQs,
+  approveRFQ,
+  rejectRFQ,
+  getStripeRevenue,
 } = require('../controllers/admin');
 
 const router = express.Router();
 
 router.get('/metrics', auth, isAdmin, getMetrics);
 router.get('/users', auth, isAdmin, getUsers);
+router.put('/users/:id', auth, isAdmin, updateUser);
 router.delete('/users/:id', auth, isAdmin, deleteUser);
 router.get('/listings', auth, isAdmin, getListings);
 router.post('/listings/:id/approve', auth, isAdmin, approveListing);
 router.delete('/listings/:id', auth, isAdmin, deleteListing);
+router.get('/rfqs', auth, isAdmin, getRFQs);
+router.post('/rfqs/:id/approve', auth, isAdmin, approveRFQ);
+router.post('/rfqs/:id/reject', auth, isAdmin, rejectRFQ);
+router.get('/revenue', auth, isAdmin, getStripeRevenue);
 
 module.exports = router;
 

--- a/frontend/pages/admin/index.js
+++ b/frontend/pages/admin/index.js
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
-import { useAuth } from '../contexts/AuthContext';
-import withAuth from '../components/withAuth';
+import { useAuth } from '../../contexts/AuthContext';
+import withAuth from '../../components/withAuth';
 
-function Admin() {
+function AdminDashboard() {
   const { user } = useAuth();
   const [metrics, setMetrics] = useState(null);
 
@@ -35,7 +35,7 @@ function Admin() {
         </div>
         <div className="p-4 border rounded">
           <h2 className="text-xl">Revenue</h2>
-          <p className="text-3xl">${metrics.revenue}</p>
+          <p className="text-3xl">${metrics.totalRevenue}</p>
         </div>
         <div className="p-4 border rounded">
           <h2 className="text-xl">Pending Listings</h2>
@@ -46,4 +46,5 @@ function Admin() {
   );
 }
 
-export default withAuth(Admin, 'admin');
+export default withAuth(AdminDashboard, 'admin');
+

--- a/frontend/pages/admin/offers.js
+++ b/frontend/pages/admin/offers.js
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import withAuth from '../../components/withAuth';
+
+function AdminOffers() {
+  const [offers, setOffers] = useState([]);
+
+  const fetchOffers = async () => {
+    try {
+      const res = await axios.get('http://localhost:5000/api/v1/admin/listings', {
+        withCredentials: true,
+      });
+      setOffers(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchOffers();
+  }, []);
+
+  const approve = async (id) => {
+    try {
+      await axios.post(
+        `http://localhost:5000/api/v1/admin/listings/${id}/approve`,
+        {},
+        { withCredentials: true }
+      );
+      fetchOffers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const remove = async (id) => {
+    try {
+      await axios.delete(
+        `http://localhost:5000/api/v1/admin/listings/${id}`,
+        { withCredentials: true }
+      );
+      fetchOffers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Manage Offers</h1>
+      <ul>
+        {offers.map((offer) => (
+          <li key={offer.id} className="border p-2 mb-2">
+            {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status}
+            <div className="mt-2 space-x-2">
+              {offer.status === 'pending' && (
+                <button
+                  className="bg-green-500 text-white px-2 py-1"
+                  onClick={() => approve(offer.id)}
+                >
+                  Approve
+                </button>
+              )}
+              <button
+                className="bg-red-500 text-white px-2 py-1"
+                onClick={() => remove(offer.id)}
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(AdminOffers, 'admin');
+

--- a/frontend/pages/admin/reports.js
+++ b/frontend/pages/admin/reports.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import withAuth from '../../components/withAuth';
+
+function AdminReports() {
+  const [revenue, setRevenue] = useState(null);
+
+  useEffect(() => {
+    const fetchRevenue = async () => {
+      try {
+        const res = await axios.get('http://localhost:5000/api/v1/admin/revenue', {
+          withCredentials: true,
+        });
+        setRevenue(res.data.revenue);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchRevenue();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Reports</h1>
+      {revenue === null ? (
+        <p>Loading...</p>
+      ) : (
+        <p className="text-xl">Total Stripe Revenue: ${revenue}</p>
+      )}
+    </div>
+  );
+}
+
+export default withAuth(AdminReports, 'admin');
+

--- a/frontend/pages/admin/rfqs.js
+++ b/frontend/pages/admin/rfqs.js
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import withAuth from '../../components/withAuth';
+
+function AdminRFQs() {
+  const [rfqs, setRfqs] = useState([]);
+
+  const fetchRFQs = async () => {
+    try {
+      const res = await axios.get('http://localhost:5000/api/v1/admin/rfqs', {
+        withCredentials: true,
+      });
+      setRfqs(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchRFQs();
+  }, []);
+
+  const approve = async (id) => {
+    try {
+      await axios.post(
+        `http://localhost:5000/api/v1/admin/rfqs/${id}/approve`,
+        {},
+        { withCredentials: true }
+      );
+      fetchRFQs();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const reject = async (id) => {
+    try {
+      await axios.post(
+        `http://localhost:5000/api/v1/admin/rfqs/${id}/reject`,
+        {},
+        { withCredentials: true }
+      );
+      fetchRFQs();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Manage RFQs</h1>
+      <ul>
+        {rfqs.map((rfq) => (
+          <li key={rfq.id} className="border p-2 mb-2">
+            {rfq.symbol} - {rfq.quantity} - {rfq.status}
+            <div className="mt-2 space-x-2">
+              {rfq.status === 'pending' && (
+                <>
+                  <button
+                    className="bg-green-500 text-white px-2 py-1"
+                    onClick={() => approve(rfq.id)}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    className="bg-yellow-500 text-white px-2 py-1"
+                    onClick={() => reject(rfq.id)}
+                  >
+                    Reject
+                  </button>
+                </>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(AdminRFQs, 'admin');
+

--- a/frontend/pages/admin/users.js
+++ b/frontend/pages/admin/users.js
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import withAuth from '../../components/withAuth';
+
+function AdminUsers() {
+  const [users, setUsers] = useState([]);
+
+  const fetchUsers = async () => {
+    try {
+      const res = await axios.get('http://localhost:5000/api/v1/admin/users', {
+        withCredentials: true,
+      });
+      setUsers(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const handleRoleChange = (id, value) => {
+    setUsers((prev) =>
+      prev.map((u) => (u.id === id ? { ...u, role: value } : u))
+    );
+  };
+
+  const handleSubscriptionChange = (id, value) => {
+    setUsers((prev) =>
+      prev.map((u) => (u.id === id ? { ...u, subscriptionStatus: value } : u))
+    );
+  };
+
+  const handleUpdate = async (user) => {
+    try {
+      await axios.put(
+        `http://localhost:5000/api/v1/admin/users/${user.id}`,
+        {
+          role: user.role,
+          subscriptionStatus: user.subscriptionStatus,
+        },
+        { withCredentials: true }
+      );
+      fetchUsers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Manage Users</h1>
+      <ul>
+        {users.map((user) => (
+          <li key={user.id} className="border p-2 mb-2 flex space-x-2 items-center">
+            <span className="flex-1">{user.username}</span>
+            <select
+              className="border p-1"
+              value={user.role}
+              onChange={(e) => handleRoleChange(user.id, e.target.value)}
+            >
+              <option value="subscriber">subscriber</option>
+              <option value="admin">admin</option>
+            </select>
+            <select
+              className="border p-1"
+              value={user.subscriptionStatus || 'inactive'}
+              onChange={(e) =>
+                handleSubscriptionChange(user.id, e.target.value)
+              }
+            >
+              <option value="inactive">inactive</option>
+              <option value="active">active</option>
+            </select>
+            <button
+              className="bg-blue-500 text-white px-2 py-1"
+              onClick={() => handleUpdate(user)}
+            >
+              Update
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(AdminUsers, 'admin');
+


### PR DESCRIPTION
## Summary
- add admin controller methods for RFQ moderation, user updates, and Stripe revenue
- expose admin routes and frontend pages for users, offers, RFQs, and reports
- allow RFQ status to include rejected

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e0605cef08325ab25fe770589b947