### PR TITLE
Add buyer and seller roles with dashboards

### DIFF
--- a/backend/migrations/20240901000000-create-users.js
+++ b/backend/migrations/20240901000000-create-users.js
@@ -6,7 +6,10 @@ module.exports = {
       id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
       username: { type: Sequelize.STRING, allowNull: false, unique: true },
       password: { type: Sequelize.STRING, allowNull: false },
-      role: { type: Sequelize.STRING, allowNull: false },
+      role: {
+        type: Sequelize.ENUM('buyer', 'seller', 'admin', 'subscriber'),
+        allowNull: false,
+      },
       subscriptionStatus: { type: Sequelize.STRING, defaultValue: 'inactive' },
       verificationToken: { type: Sequelize.STRING },
       resetToken: { type: Sequelize.STRING },

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -8,7 +8,10 @@ module.exports = (sequelize) => {
       id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
       username: { type: DataTypes.STRING, allowNull: false, unique: true },
       password: { type: DataTypes.STRING, allowNull: false },
-      role: { type: DataTypes.STRING, allowNull: false },
+      role: {
+        type: DataTypes.ENUM('buyer', 'seller', 'admin', 'subscriber'),
+        allowNull: false,
+      },
       subscriptionStatus: { type: DataTypes.STRING, defaultValue: 'inactive' },
       verificationToken: { type: DataTypes.STRING },
       resetToken: { type: DataTypes.STRING },

--- a/backend/seeders/20240901000005-demo-users.js
+++ b/backend/seeders/20240901000005-demo-users.js
@@ -10,7 +10,7 @@ module.exports = {
       {
         username: 'alice',
         password: password1,
-        role: 'trader',
+        role: 'buyer',
         subscriptionStatus: 'active',
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -18,7 +18,7 @@ module.exports = {
       {
         username: 'bob',
         password: password2,
-        role: 'broker',
+        role: 'seller',
         subscriptionStatus: 'inactive',
         createdAt: new Date(),
         updatedAt: new Date(),

--- a/frontend/components/withAuth.js
+++ b/frontend/components/withAuth.js
@@ -7,19 +7,32 @@ export default function withAuth(Component, requiredRole) {
     const { user, loading } = useAuth();
     const router = useRouter();
 
+    const getDashboard = (role) => {
+      switch (role) {
+        case 'buyer':
+          return '/buyer/dashboard';
+        case 'seller':
+          return '/seller/dashboard';
+        case 'admin':
+          return '/admin';
+        default:
+          return '/';
+      }
+    };
+
     useEffect(() => {
       if (loading) return;
       if (!user) {
         router.replace('/login');
       } else if (requiredRole && user.role !== requiredRole) {
-        router.replace('/');
+        router.replace(getDashboard(user.role));
       } else if (
         user.role === 'subscriber' &&
         user.subscriptionStatus !== 'active'
       ) {
         router.replace('/pricing');
       }
-    }, [user, loading, router]);
+    }, [user, loading, router, requiredRole]);
 
     if (
       loading ||

--- a/frontend/pages/admin/users.js
+++ b/frontend/pages/admin/users.js
@@ -60,6 +60,8 @@ function AdminUsers() {
               value={user.role}
               onChange={(e) => handleRoleChange(user.id, e.target.value)}
             >
+              <option value="buyer">buyer</option>
+              <option value="seller">seller</option>
               <option value="subscriber">subscriber</option>
               <option value="admin">admin</option>
             </select>

--- a/frontend/pages/buyer/dashboard.js
+++ b/frontend/pages/buyer/dashboard.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import Link from 'next/link';
+import withAuth from '../../components/withAuth';
+
+function BuyerDashboard() {
+  const [offers, setOffers] = useState([]);
+
+  useEffect(() => {
+    const fetchOffers = async () => {
+      try {
+        const res = await axios.get('http://localhost:5000/api/v1/offers', {
+          withCredentials: true,
+        });
+        setOffers(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchOffers();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Buyer Dashboard</h1>
+      <Link href="/rfqs/new" className="bg-green-500 text-white px-4 py-2 mb-4 inline-block">
+        Create RFQ
+      </Link>
+      <h2 className="text-xl mt-4 mb-2">Available Offers</h2>
+      <ul>
+        {offers.map((offer) => (
+          <li key={offer.id} className="border p-2 mb-2">
+            {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(BuyerDashboard, 'buyer');

--- a/frontend/pages/seller/dashboard.js
+++ b/frontend/pages/seller/dashboard.js
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import Link from 'next/link';
+import withAuth from '../../components/withAuth';
+
+function SellerDashboard() {
+  const [rfqs, setRfqs] = useState([]);
+
+  useEffect(() => {
+    const fetchRfqs = async () => {
+      try {
+        const res = await axios.get('http://localhost:5000/api/v1/rfqs', {
+          withCredentials: true,
+        });
+        setRfqs(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchRfqs();
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Seller Dashboard</h1>
+      <Link href="/offers/new" className="bg-green-500 text-white px-4 py-2 mb-4 inline-block">
+        Create Offer
+      </Link>
+      <h2 className="text-xl mt-4 mb-2">Recent RFQs</h2>
+      <ul>
+        {rfqs.map((rfq) => (
+          <li key={rfq.id} className="border p-2 mb-2">
+            {rfq.symbol} - {rfq.quantity} - {rfq.status}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(SellerDashboard, 'seller');


### PR DESCRIPTION
## Summary
- add buyer and seller roles to the user schema and seed data
- provide separate buyer and seller dashboards
- redirect unauthorized users to their role-specific dashboards

## Testing
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e08862f0083259d9b1c513fa47185