### PR TITLE
Add category and lastUpdated fields to market data

### DIFF
--- a/backend/migrations/20240901000003-create-marketdata.js
+++ b/backend/migrations/20240901000003-create-marketdata.js
@@ -9,6 +9,8 @@ module.exports = {
       changePercent: { type: Sequelize.FLOAT, allowNull: true },
       historical: { type: Sequelize.JSON, allowNull: false, defaultValue: [] },
       forecast: { type: Sequelize.JSON, allowNull: false, defaultValue: [] },
+      category: { type: Sequelize.STRING, allowNull: false },
+      lastUpdated: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
       createdAt: { allowNull: false, type: Sequelize.DATE },
       updatedAt: { allowNull: false, type: Sequelize.DATE },
     });

--- a/backend/models/MarketData.js
+++ b/backend/models/MarketData.js
@@ -8,6 +8,8 @@ module.exports = (sequelize) => {
     changePercent: { type: DataTypes.FLOAT, allowNull: true },
     historical: { type: DataTypes.JSON, allowNull: false, defaultValue: [] },
     forecast: { type: DataTypes.JSON, allowNull: false, defaultValue: [] },
+    category: { type: DataTypes.STRING, allowNull: false },
+    lastUpdated: { type: DataTypes.DATE, allowNull: false, defaultValue: DataTypes.NOW },
   });
   return MarketData;
 };

--- a/backend/services/marketDataService.js
+++ b/backend/services/marketDataService.js
@@ -4,6 +4,7 @@ const { movingAverageForecast } = require('../utils/forecast');
 const SOURCES = [
   {
     commodity: 'gold',
+    category: 'metals',
     fetch: async () => {
       try {
         const response = await fetch('https://data-asg.goldprice.org/dbXRates/USD');
@@ -21,6 +22,7 @@ const SOURCES = [
   },
   {
     commodity: 'silver',
+    category: 'metals',
     fetch: async () => {
       try {
         const response = await fetch('https://data-asg.goldprice.org/dbXRates/USD');
@@ -38,6 +40,7 @@ const SOURCES = [
   },
   {
     commodity: 'wti',
+    category: 'energy',
     fetch: async () => {
       try {
         const response = await fetch(`https://www.alphavantage.co/query?function=WTI&interval=daily&apikey=${process.env.ALPHAVANTAGE_KEY}`);
@@ -62,6 +65,7 @@ const SOURCES = [
   },
   {
     commodity: 'corn',
+    category: 'agriculture',
     fetch: async () => {
       try {
         const response = await fetch(`https://www.alphavantage.co/query?function=CORN&interval=daily&apikey=${process.env.ALPHAVANTAGE_KEY}`);
@@ -91,6 +95,7 @@ async function fetchCommodity(source) {
   const date = result.date || new Date().toISOString().split('T')[0];
   return {
     commodity: source.commodity,
+    category: source.category,
     currentPrice: result.currentPrice,
     changePercent: result.changePercent,
     entry: { date, price: result.currentPrice },
@@ -111,16 +116,25 @@ async function refreshMarketData() {
       const forecast = movingAverageForecast(historical);
       return {
         commodity: u.commodity,
+        category: u.category,
         currentPrice: u.currentPrice,
         changePercent: u.changePercent,
         historical,
         forecast,
+        lastUpdated: new Date(),
       };
     });
 
     if (payload.length > 0) {
       await MarketData.bulkCreate(payload, {
-        updateOnDuplicate: ['currentPrice', 'changePercent', 'historical', 'forecast'],
+        updateOnDuplicate: [
+          'category',
+          'currentPrice',
+          'changePercent',
+          'historical',
+          'forecast',
+          'lastUpdated',
+        ],
       });
     }
   } catch (err) {

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -17,6 +17,7 @@ function Dashboard() {
   const [watchlist, setWatchlist] = useState([]);
   const [news, setNews] = useState([]);
   const [forecastData, setForecastData] = useState([]);
+  const [marketInfo, setMarketInfo] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -34,6 +35,11 @@ function Dashboard() {
           'http://localhost:5000/api/v1/forecast/gold',
           { withCredentials: true }
         );
+        const marketRes = await axios.get(
+          'http://localhost:5000/api/v1/marketData/gold',
+          { withCredentials: true }
+        );
+        setMarketInfo(marketRes.data);
         const { historical = [], forecast = [] } = forecastRes.data;
         const combined = historical.map((h) => ({
           date: h.date,
@@ -67,6 +73,12 @@ function Dashboard() {
         </ResponsiveContainer>
       </div>
       <h1 className="text-2xl mt-8 mb-4">Gold Price Forecast</h1>
+      {marketInfo && (
+        <p className="mb-2 text-sm">
+          Category: {marketInfo.category} | Last Updated:{' '}
+          {new Date(marketInfo.lastUpdated).toLocaleString()}
+        </p>
+      )}
       <div style={{ width: '100%', height: 300 }}>
         <ResponsiveContainer>
           <LineChart data={forecastData}>


### PR DESCRIPTION
## Summary
- extend market data model and migration with `category` and `lastUpdated`
- populate new fields during refresh and expose via API and dashboard

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ec6e8428c8325891a3ab0814a0bff