### PR TITLE
Use cron scheduling for market data service

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "express-rate-limit": "^6.11.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.2",
+        "node-cron": "^4.2.1",
         "nodemailer": "^6.9.13",
         "pg": "^8.16.3",
         "pg-hstore": "^2.3.4",
@@ -2269,6 +2270,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "express-rate-limit": "^6.11.2",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.2",
+    "node-cron": "^4.2.1",
     "nodemailer": "^6.9.13",
     "pg": "^8.16.3",
     "pg-hstore": "^2.3.4",

--- a/backend/services/marketDataService.js
+++ b/backend/services/marketDataService.js
@@ -1,5 +1,6 @@
 const { MarketData } = require('../models');
 const { movingAverageForecast } = require('../utils/forecast');
+const cron = require('node-cron');
 
 const SOURCES = [
   {
@@ -15,7 +16,7 @@ const SOURCES = [
           changePercent: item.pcXau,
         };
       } catch (err) {
-        console.error('Failed to fetch gold data', err);
+        console.warn('Failed to fetch gold data', err);
         throw err;
       }
     },
@@ -33,7 +34,7 @@ const SOURCES = [
           changePercent: item.pcXag,
         };
       } catch (err) {
-        console.error('Failed to fetch silver data', err);
+        console.warn('Failed to fetch silver data', err);
         throw err;
       }
     },
@@ -58,7 +59,7 @@ const SOURCES = [
           date: latest.date || latest.timestamp || new Date().toISOString().split('T')[0],
         };
       } catch (err) {
-        console.error('Failed to fetch WTI data', err);
+        console.warn('Failed to fetch WTI data', err);
         throw err;
       }
     },
@@ -83,7 +84,7 @@ const SOURCES = [
           date: latest.date || latest.timestamp || new Date().toISOString().split('T')[0],
         };
       } catch (err) {
-        console.error('Failed to fetch corn data', err);
+        console.warn('Failed to fetch corn data', err);
         throw err;
       }
     },
@@ -144,8 +145,7 @@ async function refreshMarketData() {
 
 function scheduleMarketDataRefresh() {
   refreshMarketData();
-  const fifteenMinutes = 15 * 60 * 1000;
-  setInterval(refreshMarketData, fifteenMinutes);
+  cron.schedule('*/15 * * * *', refreshMarketData);
 }
 
 module.exports = { refreshMarketData, scheduleMarketDataRefresh };


### PR DESCRIPTION
## Summary
- install node-cron and schedule refresh every 15 minutes via cron
- warn when individual commodity data fetch fails

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ec85d3a908325a96352b3aff3a9e5