### PR TITLE
Add commodity selector to dashboard

### DIFF
--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -18,25 +18,46 @@ function Dashboard() {
   const [news, setNews] = useState([]);
   const [forecastData, setForecastData] = useState([]);
   const [marketInfo, setMarketInfo] = useState(null);
+  const [selectedSymbol, setSelectedSymbol] = useState('gold');
+  const [symbols, setSymbols] = useState([]);
+
+  const formatSymbol = (sym) => sym ? sym.charAt(0).toUpperCase() + sym.slice(1) : '';
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchInitialData = async () => {
       try {
-        const watchlistRes = await axios.get(
-          'http://localhost:5000/api/v1/watchlist',
-          { withCredentials: true }
-        );
+        const [watchlistRes, newsRes, symbolsRes] = await Promise.all([
+          axios.get('http://localhost:5000/api/v1/watchlist', {
+            withCredentials: true,
+          }),
+          axios.get('http://localhost:5000/api/v1/news', {
+            withCredentials: true,
+          }),
+          axios.get('http://localhost:5000/api/v1/market-data', {
+            withCredentials: true,
+          }),
+        ]);
         setWatchlist(watchlistRes.data);
-        const newsRes = await axios.get('http://localhost:5000/api/v1/news', {
-          withCredentials: true,
-        });
         setNews(newsRes.data);
+        setSymbols(symbolsRes.data || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    if (user) {
+      fetchInitialData();
+    }
+  }, [user]);
+
+  useEffect(() => {
+    const fetchForecast = async () => {
+      try {
         const forecastRes = await axios.get(
-          'http://localhost:5000/api/v1/forecast/gold',
+          `http://localhost:5000/api/v1/forecast/${selectedSymbol}`,
           { withCredentials: true }
         );
         const marketRes = await axios.get(
-          'http://localhost:5000/api/v1/marketData/gold',
+          `http://localhost:5000/api/v1/marketData/${selectedSymbol}`,
           { withCredentials: true }
         );
         setMarketInfo(marketRes.data);
@@ -54,9 +75,9 @@ function Dashboard() {
       }
     };
     if (user) {
-      fetchData();
+      fetchForecast();
     }
-  }, [user]);
+  }, [user, selectedSymbol]);
 
   return (
     <div className="p-4">
@@ -72,24 +93,59 @@ function Dashboard() {
           </LineChart>
         </ResponsiveContainer>
       </div>
-      <h1 className="text-2xl mt-8 mb-4">Gold Price Forecast</h1>
-      {marketInfo && (
-        <p className="mb-2 text-sm">
-          Category: {marketInfo.category} | Last Updated:{' '}
-          {new Date(marketInfo.lastUpdated).toLocaleString()}
-        </p>
-      )}
-      <div style={{ width: '100%', height: 300 }}>
-        <ResponsiveContainer>
-          <LineChart data={forecastData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="historical" stroke="#8884d8" name="Historical" />
-            <Line type="monotone" dataKey="forecast" stroke="#82ca9d" name="Forecast" />
-          </LineChart>
-        </ResponsiveContainer>
+      <div className="mt-8">
+        <div className="mb-4">
+          <label htmlFor="symbol-select" className="mr-2">
+            Commodity:
+          </label>
+          <select
+            id="symbol-select"
+            value={selectedSymbol}
+            onChange={(e) => setSelectedSymbol(e.target.value)}
+            className="border p-1"
+          >
+            {symbols.length > 0 ? (
+              symbols.map((sym) => (
+                <option key={sym} value={sym}>
+                  {sym.toUpperCase()}
+                </option>
+              ))
+            ) : (
+              <option value="gold">Gold</option>
+            )}
+          </select>
+        </div>
+        <h1 className="text-2xl mb-4">
+          {formatSymbol(selectedSymbol)} Price Forecast
+        </h1>
+        {marketInfo && (
+          <p className="mb-2 text-sm">
+            Category: {marketInfo.category} | Last Updated:{' '}
+            {new Date(marketInfo.lastUpdated).toLocaleString()}
+          </p>
+        )}
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <LineChart data={forecastData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Line
+                type="monotone"
+                dataKey="historical"
+                stroke="#8884d8"
+                name="Historical"
+              />
+              <Line
+                type="monotone"
+                dataKey="forecast"
+                stroke="#82ca9d"
+                name="Forecast"
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
       </div>
       <h2 className="text-xl mt-8 mb-2">Watchlist Items</h2>
       <ul>


### PR DESCRIPTION
## Summary
- add commodity dropdown to dashboard
- fetch forecasts and market info for selected symbol
- preload commodity list from `/api/v1/market-data`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ec9a45fcc83259dd926ebceb77833