### PR TITLE
Seed market data and align refresh with initial history

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,3 +15,5 @@ Populate the database with sample data:
 ```bash
 npm run seed
 ```
+
+This loads initial market data from `data/marketData.json` so scheduled refreshes have historical prices to build on.

--- a/backend/seeders/20240901000007-demo-market-data.js
+++ b/backend/seeders/20240901000007-demo-market-data.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { movingAverageForecast } = require('../utils/forecast');
+
+module.exports = {
+  async up(queryInterface) {
+    const filePath = path.join(__dirname, '..', 'data', 'marketData.json');
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const json = JSON.parse(raw);
+
+    const categoryMap = {
+      gold: 'metals',
+      silver: 'metals',
+      crude_oil: 'energy',
+    };
+
+    const records = Object.entries(json).map(([commodity, historical]) => {
+      const last = historical[historical.length - 1];
+      const prev = historical[historical.length - 2] || last;
+      const currentPrice = last.price;
+      const changePercent = ((currentPrice - prev.price) / prev.price) * 100;
+      return {
+        commodity,
+        category: categoryMap[commodity] || 'other',
+        currentPrice,
+        changePercent,
+        historical,
+        forecast: movingAverageForecast(historical),
+        lastUpdated: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    });
+
+    await queryInterface.bulkInsert('MarketData', records);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('MarketData', {
+      commodity: ['gold', 'silver', 'crude_oil'],
+    });
+  },
+};
+

--- a/backend/services/marketDataService.js
+++ b/backend/services/marketDataService.js
@@ -40,7 +40,7 @@ const SOURCES = [
     },
   },
   {
-    commodity: 'wti',
+    commodity: 'crude_oil',
     category: 'energy',
     fetch: async () => {
       try {
@@ -59,7 +59,7 @@ const SOURCES = [
           date: latest.date || latest.timestamp || new Date().toISOString().split('T')[0],
         };
       } catch (err) {
-        console.warn('Failed to fetch WTI data', err);
+        console.warn('Failed to fetch crude oil data', err);
         throw err;
       }
     },


### PR DESCRIPTION
## Summary
- seed MarketData table from `data/marketData.json`
- align scheduled refresh with `crude_oil` data and append new entries to seeded history
- document `npm run seed` usage in backend README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run seed` *(fails: no database configured)*

------
https://chatgpt.com/codex/tasks/task_e_689eccc1381c8325a8642d779179054b