### PR TITLE
feat: add brand design tokens and design guide

### DIFF
--- a/frontend/docs/design-guide.md
+++ b/frontend/docs/design-guide.md
@@ -1,0 +1,24 @@
+# Design Guide
+
+This guide outlines the shared design tokens available in Tailwind for the FalconTrade frontend.
+
+## Colors
+
+The `brand` palette is available in both background and text utilities.
+
+| Token | Class Examples | Hex |
+|-------|----------------|-----|
+| `brand` (default) | `text-brand`, `bg-brand` | `#1A56DB` |
+| `brand-light` | `text-brand-light`, `bg-brand-light` | `#3B82F6` |
+| `brand-dark` | `text-brand-dark`, `bg-brand-dark` | `#1E3A8A` |
+| `brand-secondary` | `text-brand-secondary`, `bg-brand-secondary` | `#7E3AF2` |
+| `brand-accent` | `text-brand-accent`, `bg-brand-accent` | `#16BDCA` |
+| `brand-background` | `bg-brand-background` | `#F5F7FA` |
+| `brand-foreground` | `text-brand-foreground` | `#1F2937` |
+
+## Typography
+
+- `font-sans` – applies the base font stack: **Inter**, **Roboto**, `sans-serif` fallback.
+- `font-heading` – use for headings; stack of **Roboto**, **Inter**, `sans-serif`.
+
+These utilities can be combined with standard Tailwind text size and weight classes to compose typography styles.

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    @apply font-sans bg-brand-background text-brand-foreground;
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,7 +6,27 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: '#1A56DB',
+          light: '#3B82F6',
+          dark: '#1E3A8A',
+          secondary: '#7E3AF2',
+          accent: '#16BDCA',
+          background: '#F5F7FA',
+          foreground: '#1F2937'
+        }
+      },
+      fontFamily: {
+        sans: ['Inter', 'Roboto', 'sans-serif'],
+        heading: ['Roboto', 'Inter', 'sans-serif']
+      },
+      spacing: {
+        '128': '32rem',
+        '144': '36rem'
+      }
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind theme with brand colors, font families, and spacing tokens
- document color and typography utilities in a developer design guide
- apply base fonts and background colors globally using new tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ece82cd0083259e61128b56f37c1c