### PR TITLE
feat: add responsive layout and navigation

### DIFF
--- a/frontend/components/Layout.js
+++ b/frontend/components/Layout.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Layout({ children, header, footer }) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      {header}
+      <main className="flex-grow container mx-auto px-4 py-8">
+        {children}
+      </main>
+      {footer && <footer className="mt-auto">{footer}</footer>}
+    </div>
+  );
+}

--- a/frontend/components/PublicNav.js
+++ b/frontend/components/PublicNav.js
@@ -1,15 +1,72 @@
+import { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 export default function PublicNav() {
+  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+
+  const links = [
+    { href: '/', label: 'Home' },
+    { href: '/about', label: 'About' },
+    { href: '/pricing', label: 'Pricing' },
+    { href: '/faq', label: 'FAQ' },
+    { href: '/contact', label: 'Contact' },
+    { href: '/login', label: 'Login' },
+    { href: '/signup', label: 'Sign Up' },
+  ];
+
+  const linkClass = (href) =>
+    router.pathname === href
+      ? 'text-brand-dark dark:text-brand-light border-b-2 border-brand-dark dark:border-brand-light'
+      : 'text-gray-700 dark:text-gray-300 hover:text-brand-dark dark:hover:text-brand-light';
+
   return (
-    <nav className="p-4 space-x-4 bg-gray-100 dark:bg-gray-800">
-      <Link href="/">Home</Link>
-      <Link href="/about">About</Link>
-      <Link href="/pricing">Pricing</Link>
-      <Link href="/faq">FAQ</Link>
-      <Link href="/contact">Contact</Link>
-      <Link href="/login">Login</Link>
-      <Link href="/signup">Sign Up</Link>
+    <nav className="bg-gray-100 dark:bg-gray-800">
+      <div className="container mx-auto px-4">
+        <div className="flex items-center justify-between py-4">
+          <div className="text-xl font-bold">
+            <Link href="/">FalconTrade</Link>
+          </div>
+          <button
+            className="md:hidden text-gray-700 dark:text-gray-300 focus:outline-none"
+            onClick={() => setIsOpen(!isOpen)}
+            aria-label="Toggle navigation"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              {isOpen ? (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              )}
+            </svg>
+          </button>
+          <ul className="hidden md:flex space-x-6">
+            {links.map(({ href, label }) => (
+              <li key={href}>
+                <Link href={href} className={`pb-1 ${linkClass(href)}`}>
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+        {isOpen && (
+          <ul className="md:hidden pb-4 space-y-2">
+            {links.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={`block ${linkClass(href)}`}
+                  onClick={() => setIsOpen(false)}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </nav>
   );
 }

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -2,14 +2,16 @@ import '../styles/globals.css';
 import { AuthProvider, useAuth } from '../contexts/AuthContext';
 import ThemeToggle from '../components/ThemeToggle';
 import PublicNav from '../components/PublicNav';
+import Layout from '../components/Layout';
 
 function AppContent({ Component, pageProps }) {
   const { user } = useAuth();
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 text-black dark:text-white">
       <ThemeToggle />
-      {!user && <PublicNav />}
-      <Component {...pageProps} />
+      <Layout header={!user && <PublicNav />}>
+        <Component {...pageProps} />
+      </Layout>
     </div>
   );
 }

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -2,23 +2,41 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="p-8">
-      <h1 className="text-4xl mb-4">Welcome to FalconTrade</h1>
-      <p className="mb-4">Track the markets and manage your portfolio with ease.</p>
-      <ul className="list-disc pl-5 space-y-2">
-        <li>
-          <Link href="/about">Learn more about us</Link>
-        </li>
-        <li>
-          <Link href="/pricing">View pricing plans</Link>
-        </li>
-        <li>
-          <Link href="/faq">Read our FAQ</Link>
-        </li>
-        <li>
-          <Link href="/contact">Contact us</Link>
-        </li>
-      </ul>
+    <div className="space-y-16">
+      <section className="py-16 text-center">
+        <h1 className="text-5xl font-bold mb-6">Welcome to FalconTrade</h1>
+        <p className="text-xl mb-8">Track markets, manage portfolios, and trade smarter with enterprise-grade tools.</p>
+        <div className="space-x-4">
+          <Link href="/signup" className="px-6 py-3 bg-brand text-white rounded-md hover:bg-brand-dark">
+            Get Started
+          </Link>
+          <Link href="/pricing" className="px-6 py-3 border border-brand text-brand rounded-md hover:bg-brand hover:text-white">
+            View Pricing
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid gap-8 md:grid-cols-3">
+        <div className="p-6 bg-gray-50 dark:bg-gray-800 rounded-lg shadow">
+          <h2 className="text-2xl font-semibold mb-2">Real-Time Data</h2>
+          <p className="text-gray-600 dark:text-gray-300">Stay informed with up-to-the-minute market information across exchanges.</p>
+        </div>
+        <div className="p-6 bg-gray-50 dark:bg-gray-800 rounded-lg shadow">
+          <h2 className="text-2xl font-semibold mb-2">Portfolio Analytics</h2>
+          <p className="text-gray-600 dark:text-gray-300">Gain insights into your holdings with detailed performance analytics.</p>
+        </div>
+        <div className="p-6 bg-gray-50 dark:bg-gray-800 rounded-lg shadow">
+          <h2 className="text-2xl font-semibold mb-2">Secure Trading</h2>
+          <p className="text-gray-600 dark:text-gray-300">Execute trades with confidence on our enterprise-grade platform.</p>
+        </div>
+      </section>
+
+      <section className="text-center">
+        <p className="mb-4">Have questions?</p>
+        <Link href="/contact" className="text-brand hover:underline">
+          Contact our team
+        </Link>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add flexible Layout wrapper with container and header/footer slots
- implement mobile-first navigation bar with hamburger toggle and active links
- redesign homepage with hero and feature grid for premium aesthetics

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ecf98067c8325bcf3ab212542aea2