### PR TITLE
feat: add advanced filters for offers and rfqs

### DIFF
--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -4,6 +4,7 @@ const multer = require('multer');
 const auth = require('../middleware/auth');
 const { isAdmin, isSubscriber } = require('../middleware/roles');
 const { RFQ } = require('../models');
+const { Op } = require('sequelize');
 
 const router = express.Router();
 
@@ -50,10 +51,34 @@ router.post(
 
 // Get all RFQs
 router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
-  const { commodity, status, sortBy, order } = req.query;
+  const {
+    commodity,
+    status,
+    sortBy,
+    order,
+    minQuantity,
+    maxQuantity,
+    location,
+  } = req.query;
+
   const where = {};
-  if (commodity) where.symbol = commodity;
+
+  if (commodity) {
+    where.symbol = { [Op.iLike]: `%${commodity}%` };
+  }
+
   if (status) where.status = status;
+
+  if (location) {
+    where.location = { [Op.iLike]: `%${location}%` };
+  }
+
+  if (minQuantity || maxQuantity) {
+    where.quantity = {};
+    if (minQuantity) where.quantity[Op.gte] = parseInt(minQuantity, 10);
+    if (maxQuantity) where.quantity[Op.lte] = parseInt(maxQuantity, 10);
+  }
+
   const options = { where };
   if (sortBy) {
     options.order = [

--- a/frontend/pages/offers/index.js
+++ b/frontend/pages/offers/index.js
@@ -9,12 +9,22 @@ function Offers() {
   const [status, setStatus] = useState('');
   const [sortBy, setSortBy] = useState('');
   const [order, setOrder] = useState('ASC');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const [minQuantity, setMinQuantity] = useState('');
+  const [maxQuantity, setMaxQuantity] = useState('');
+  const [location, setLocation] = useState('');
 
   const fetchOffers = async () => {
     try {
       const params = {};
       if (commodity) params.commodity = commodity;
       if (status) params.status = status;
+      if (minPrice) params.minPrice = minPrice;
+      if (maxPrice) params.maxPrice = maxPrice;
+      if (minQuantity) params.minQuantity = minQuantity;
+      if (maxQuantity) params.maxQuantity = maxQuantity;
+      if (location) params.location = location;
       if (sortBy) {
         params.sortBy = sortBy;
         params.order = order;
@@ -48,6 +58,44 @@ function Offers() {
           value={commodity}
           onChange={(e) => setCommodity(e.target.value)}
         />
+        <input
+          className="border p-2 w-full"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
+        <div className="flex space-x-2">
+          <input
+            className="border p-2 w-full"
+            type="number"
+            placeholder="Min Price"
+            value={minPrice}
+            onChange={(e) => setMinPrice(e.target.value)}
+          />
+          <input
+            className="border p-2 w-full"
+            type="number"
+            placeholder="Max Price"
+            value={maxPrice}
+            onChange={(e) => setMaxPrice(e.target.value)}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <input
+            className="border p-2 w-full"
+            type="number"
+            placeholder="Min Quantity"
+            value={minQuantity}
+            onChange={(e) => setMinQuantity(e.target.value)}
+          />
+          <input
+            className="border p-2 w-full"
+            type="number"
+            placeholder="Max Quantity"
+            value={maxQuantity}
+            onChange={(e) => setMaxQuantity(e.target.value)}
+          />
+        </div>
         <select
           className="border p-2 w-full"
           value={status}

--- a/frontend/pages/rfqs/index.js
+++ b/frontend/pages/rfqs/index.js
@@ -9,12 +9,18 @@ function RFQs() {
   const [status, setStatus] = useState('');
   const [sortBy, setSortBy] = useState('');
   const [order, setOrder] = useState('ASC');
+  const [minQuantity, setMinQuantity] = useState('');
+  const [maxQuantity, setMaxQuantity] = useState('');
+  const [location, setLocation] = useState('');
 
   const fetchRfqs = async () => {
     try {
       const params = {};
       if (commodity) params.commodity = commodity;
       if (status) params.status = status;
+      if (minQuantity) params.minQuantity = minQuantity;
+      if (maxQuantity) params.maxQuantity = maxQuantity;
+      if (location) params.location = location;
       if (sortBy) {
         params.sortBy = sortBy;
         params.order = order;
@@ -48,6 +54,28 @@ function RFQs() {
           value={commodity}
           onChange={(e) => setCommodity(e.target.value)}
         />
+        <input
+          className="border p-2 w-full"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
+        <div className="flex space-x-2">
+          <input
+            className="border p-2 w-full"
+            type="number"
+            placeholder="Min Quantity"
+            value={minQuantity}
+            onChange={(e) => setMinQuantity(e.target.value)}
+          />
+          <input
+            className="border p-2 w-full"
+            type="number"
+            placeholder="Max Quantity"
+            value={maxQuantity}
+            onChange={(e) => setMaxQuantity(e.target.value)}
+          />
+        </div>
         <select
           className="border p-2 w-full"
           value={status}


### PR DESCRIPTION
## Summary
- support partial text and range-based filters for offers and RFQs
- expose min/max price, quantity, and location fields on frontend search forms

## Testing
- `cd backend && npm test` (fails: Missing script: "test")
- `cd ../frontend && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689ed4c5ad4c832587d95a6c53fd8302