### PR TITLE
feat: persist attachments for offers and rfqs

### DIFF
--- a/backend/migrations/20240901000007-add-attachments-to-offers.js
+++ b/backend/migrations/20240901000007-add-attachments-to-offers.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Offers', 'attachments', {
+      type: Sequelize.JSON,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Offers', 'attachments');
+  },
+};

--- a/backend/migrations/20240901000008-add-attachments-to-rfqs.js
+++ b/backend/migrations/20240901000008-add-attachments-to-rfqs.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('RFQs', 'attachments', {
+      type: Sequelize.JSON,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('RFQs', 'attachments');
+  },
+};

--- a/backend/models/Offer.js
+++ b/backend/models/Offer.js
@@ -12,6 +12,7 @@ module.exports = (sequelize) => {
       allowNull: false,
       defaultValue: 'pending',
     },
+    attachments: { type: DataTypes.JSON, allowNull: true },
   });
   return Offer;
 };

--- a/backend/models/RFQ.js
+++ b/backend/models/RFQ.js
@@ -11,6 +11,7 @@ module.exports = (sequelize) => {
       allowNull: false,
       defaultValue: 'pending',
     },
+    attachments: { type: DataTypes.JSON, allowNull: true },
   });
   return RFQ;
 };

--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -29,21 +29,20 @@ router.post(
   async (req, res) => {
     try {
       const { symbol, price, quantity } = req.body;
-      const offer = await Offer.create({
-        userId: req.user.id,
-        symbol,
-        price,
-        quantity,
-      });
       const attachments = (req.files || []).map((file) => ({
         filename: file.filename,
         url: `/uploads/${file.filename}`,
         mimetype: file.mimetype,
         size: file.size,
       }));
-      const result = offer.toJSON();
-      result.attachments = attachments;
-      res.json(result);
+      const offer = await Offer.create({
+        userId: req.user.id,
+        symbol,
+        price,
+        quantity,
+        attachments,
+      });
+      res.json(offer);
     } catch (err) {
       res.status(400).json({ error: err.message });
     }

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -29,20 +29,19 @@ router.post(
   async (req, res) => {
     try {
       const { symbol, quantity } = req.body;
-      const rfq = await RFQ.create({
-        userId: req.user.id,
-        symbol,
-        quantity,
-      });
       const attachments = (req.files || []).map((file) => ({
         filename: file.filename,
         url: `/uploads/${file.filename}`,
         mimetype: file.mimetype,
         size: file.size,
       }));
-      const result = rfq.toJSON();
-      result.attachments = attachments;
-      res.json(result);
+      const rfq = await RFQ.create({
+        userId: req.user.id,
+        symbol,
+        quantity,
+        attachments,
+      });
+      res.json(rfq);
     } catch (err) {
       res.status(400).json({ error: err.message });
     }


### PR DESCRIPTION
## Summary
- allow offers and RFQs to store attachment metadata
- save uploaded files on creation and expose attachments in responses
- add migrations for new JSON columns

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ed5ac32f88325ad705bfeaf54f9d5