### PR TITLE
Add order status tracking for offers and RFQs

### DIFF
--- a/backend/migrations/20240901000009-add-order-status-to-offers.js
+++ b/backend/migrations/20240901000009-add-order-status-to-offers.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Offers', 'orderStatus', {
+      type: Sequelize.ENUM('pending', 'shipped', 'completed'),
+      allowNull: false,
+      defaultValue: 'pending',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Offers', 'orderStatus');
+    await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_Offers_orderStatus";');
+  },
+};

--- a/backend/migrations/20240901000010-add-order-status-to-rfqs.js
+++ b/backend/migrations/20240901000010-add-order-status-to-rfqs.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('RFQs', 'orderStatus', {
+      type: Sequelize.ENUM('pending', 'shipped', 'completed'),
+      allowNull: false,
+      defaultValue: 'pending',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('RFQs', 'orderStatus');
+    await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_RFQs_orderStatus";');
+  },
+};

--- a/backend/models/Offer.js
+++ b/backend/models/Offer.js
@@ -12,6 +12,11 @@ module.exports = (sequelize) => {
       allowNull: false,
       defaultValue: 'pending',
     },
+    orderStatus: {
+      type: DataTypes.ENUM('pending', 'shipped', 'completed'),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
     attachments: { type: DataTypes.JSON, allowNull: true },
   });
   return Offer;

--- a/backend/models/RFQ.js
+++ b/backend/models/RFQ.js
@@ -11,6 +11,11 @@ module.exports = (sequelize) => {
       allowNull: false,
       defaultValue: 'pending',
     },
+    orderStatus: {
+      type: DataTypes.ENUM('pending', 'shipped', 'completed'),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
     attachments: { type: DataTypes.JSON, allowNull: true },
   });
   return RFQ;

--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -148,5 +148,23 @@ router.post('/:id/feature', auth, isAdmin, async (req, res) => {
   res.json(offer);
 });
 
+// Update order status (owner only)
+router.post('/:id/status', auth, async (req, res) => {
+  const { orderStatus } = req.body;
+  if (!['pending', 'shipped', 'completed'].includes(orderStatus)) {
+    return res.status(400).json({ message: 'Invalid order status' });
+  }
+  const offer = await Offer.findByPk(req.params.id);
+  if (!offer) {
+    return res.status(404).json({ message: 'Offer not found' });
+  }
+  if (offer.userId !== req.user.id) {
+    return res.status(403).json({ message: 'Not authorized' });
+  }
+  offer.orderStatus = orderStatus;
+  await offer.save();
+  res.json(offer);
+});
+
 module.exports = router;
 

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -139,5 +139,23 @@ router.post('/:id/feature', auth, isAdmin, async (req, res) => {
   res.json(rfq);
 });
 
+// Update order status (owner only)
+router.post('/:id/status', auth, async (req, res) => {
+  const { orderStatus } = req.body;
+  if (!['pending', 'shipped', 'completed'].includes(orderStatus)) {
+    return res.status(400).json({ message: 'Invalid order status' });
+  }
+  const rfq = await RFQ.findByPk(req.params.id);
+  if (!rfq) {
+    return res.status(404).json({ message: 'RFQ not found' });
+  }
+  if (rfq.userId !== req.user.id) {
+    return res.status(403).json({ message: 'Not authorized' });
+  }
+  rfq.orderStatus = orderStatus;
+  await rfq.save();
+  res.json(rfq);
+});
+
 module.exports = router;
 

--- a/frontend/pages/offers/[id].js
+++ b/frontend/pages/offers/[id].js
@@ -77,6 +77,8 @@ function OfferDetail() {
       <p>Symbol: {offer.symbol}</p>
       <p>Price: {offer.price}</p>
       <p>Quantity: {offer.quantity}</p>
+      <p>Status: {offer.status}</p>
+      <p>Order Status: {offer.orderStatus}</p>
       <div className="mt-4">
         <h2 className="text-xl mb-2">Conversation</h2>
         {messages.map((msg) => (

--- a/frontend/pages/offers/index.js
+++ b/frontend/pages/offers/index.js
@@ -144,7 +144,8 @@ function Offers() {
       <ul>
         {offers.map((offer) => (
           <li key={offer.id} className="border p-2 mb-2">
-            {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status}
+            {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status} -
+            {offer.orderStatus}
             <div className="mt-2 space-x-2">
               <Link
                 href={`/offers/${offer.id}`}

--- a/frontend/pages/rfqs/[id].js
+++ b/frontend/pages/rfqs/[id].js
@@ -76,6 +76,8 @@ function RFQDetail() {
       <h1 className="text-2xl mb-4">RFQ Details</h1>
       <p>Symbol: {rfq.symbol}</p>
       <p>Quantity: {rfq.quantity}</p>
+      <p>Status: {rfq.status}</p>
+      <p>Order Status: {rfq.orderStatus}</p>
       <div className="mt-4">
         <h2 className="text-xl mb-2">Conversation</h2>
         {messages.map((msg) => (

--- a/frontend/pages/rfqs/index.js
+++ b/frontend/pages/rfqs/index.js
@@ -123,7 +123,7 @@ function RFQs() {
       <ul>
         {rfqs.map((rfq) => (
           <li key={rfq.id} className="border p-2 mb-2">
-            {rfq.symbol} - {rfq.quantity} - {rfq.status}
+            {rfq.symbol} - {rfq.quantity} - {rfq.status} - {rfq.orderStatus}
             <div className="mt-2 space-x-2">
               <Link
                 href={`/rfqs/${rfq.id}`}


### PR DESCRIPTION
## Summary
- add `orderStatus` enum to Offer and RFQ models with pending/shipped/completed options
- migrations to persist order status with default pending
- allow authenticated owners to update order status and surface it on offer/RFQ listings

## Testing
- `npm test` *(backend: Missing script: "test")*
- `npm test` *(frontend: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ed8c0836c8325ae459a58250fbc1f