### PR TITLE
feat: allow admins to reject offers

### DIFF
--- a/backend/controllers/admin.js
+++ b/backend/controllers/admin.js
@@ -88,7 +88,8 @@ async function deleteUser(req, res) {
 async function getListings(req, res) {
   try {
     const offers = await Offer.findAll();
-    res.json(offers);
+    const rfqs = await RFQ.findAll();
+    res.json({ offers, rfqs });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -101,6 +102,20 @@ async function approveListing(req, res) {
       return res.status(404).json({ message: 'Listing not found' });
     }
     offer.status = 'approved';
+    await offer.save();
+    res.json(offer);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function rejectListing(req, res) {
+  try {
+    const offer = await Offer.findByPk(req.params.id);
+    if (!offer) {
+      return res.status(404).json({ message: 'Listing not found' });
+    }
+    offer.status = 'rejected';
     await offer.save();
     res.json(offer);
   } catch (err) {
@@ -179,6 +194,7 @@ module.exports = {
   deleteUser,
   getListings,
   approveListing,
+  rejectListing,
   deleteListing,
   getRFQs,
   approveRFQ,

--- a/backend/migrations/20240901000011-add-rejected-status-to-offers.js
+++ b/backend/migrations/20240901000011-add-rejected-status-to-offers.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(
+      "ALTER TYPE \"enum_Offers_status\" ADD VALUE IF NOT EXISTS 'rejected';"
+    );
+  },
+
+  async down(queryInterface) {
+    // Sequelize doesn't support removing enum values easily; recreate type
+    await queryInterface.sequelize.query(
+      "CREATE TYPE \"enum_Offers_status_old\" AS ENUM('pending','approved','featured');"
+    );
+    await queryInterface.sequelize.query(
+      "ALTER TABLE \"Offers\" ALTER COLUMN \"status\" TYPE \"enum_Offers_status_old\" USING \"status\"::text::\"enum_Offers_status_old\";"
+    );
+    await queryInterface.sequelize.query(
+      'DROP TYPE "enum_Offers_status";'
+    );
+    await queryInterface.sequelize.query(
+      'ALTER TYPE "enum_Offers_status_old" RENAME TO "enum_Offers_status";'
+    );
+  },
+};

--- a/backend/models/Offer.js
+++ b/backend/models/Offer.js
@@ -8,7 +8,7 @@ module.exports = (sequelize) => {
     price: { type: DataTypes.FLOAT, allowNull: false },
     quantity: { type: DataTypes.INTEGER, allowNull: false },
     status: {
-      type: DataTypes.ENUM('pending', 'approved', 'featured'),
+      type: DataTypes.ENUM('pending', 'approved', 'featured', 'rejected'),
       allowNull: false,
       defaultValue: 'pending',
     },

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -10,6 +10,7 @@ const {
   deleteUser,
   getListings,
   approveListing,
+  rejectListing,
   deleteListing,
   getRFQs,
   approveRFQ,
@@ -27,6 +28,7 @@ router.post('/users/:id/approve', auth, isAdmin, approveUser);
 router.delete('/users/:id', auth, isAdmin, deleteUser);
 router.get('/listings', auth, isAdmin, getListings);
 router.post('/listings/:id/approve', auth, isAdmin, approveListing);
+router.post('/listings/:id/reject', auth, isAdmin, rejectListing);
 router.delete('/listings/:id', auth, isAdmin, deleteListing);
 router.get('/rfqs', auth, isAdmin, getRFQs);
 router.post('/rfqs/:id/approve', auth, isAdmin, approveRFQ);

--- a/frontend/pages/admin/offers.js
+++ b/frontend/pages/admin/offers.js
@@ -10,7 +10,7 @@ function AdminOffers() {
       const res = await axios.get('http://localhost:5000/api/v1/admin/listings', {
         withCredentials: true,
       });
-      setOffers(res.data);
+      setOffers(res.data.offers || res.data);
     } catch (err) {
       console.error(err);
     }
@@ -45,6 +45,19 @@ function AdminOffers() {
     }
   };
 
+  const reject = async (id) => {
+    try {
+      await axios.post(
+        `http://localhost:5000/api/v1/admin/listings/${id}/reject`,
+        {},
+        { withCredentials: true }
+      );
+      fetchOffers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Manage Offers</h1>
@@ -54,12 +67,20 @@ function AdminOffers() {
             {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status}
             <div className="mt-2 space-x-2">
               {offer.status === 'pending' && (
-                <button
-                  className="bg-green-500 text-white px-2 py-1"
-                  onClick={() => approve(offer.id)}
-                >
-                  Approve
-                </button>
+                <>
+                  <button
+                    className="bg-green-500 text-white px-2 py-1"
+                    onClick={() => approve(offer.id)}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    className="bg-yellow-500 text-white px-2 py-1"
+                    onClick={() => reject(offer.id)}
+                  >
+                    Reject
+                  </button>
+                </>
               )}
               <button
                 className="bg-red-500 text-white px-2 py-1"


### PR DESCRIPTION
## Summary
- allow admins to reject offers and retrieve RFQs with listings
- expose rejection endpoint for listings
- add UI control to reject pending offers

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689edc6553c883259aa2366004de1a49