### PR TITLE
Add admin notification broadcasting

### DIFF
--- a/backend/migrations/20240901000012-create-notifications.js
+++ b/backend/migrations/20240901000012-create-notifications.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Notifications', {
+      id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+      message: { type: Sequelize.TEXT, allowNull: false },
+      targetRoles: { type: Sequelize.JSON, allowNull: false, defaultValue: [] },
+      read: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('Notifications');
+  },
+};

--- a/backend/models/Notification.js
+++ b/backend/models/Notification.js
@@ -1,0 +1,11 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const Notification = sequelize.define('Notification', {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    message: { type: DataTypes.TEXT, allowNull: false },
+    targetRoles: { type: DataTypes.JSON, allowNull: false, defaultValue: [] },
+    read: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  });
+  return Notification;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -7,6 +7,7 @@ const MarketData = require('./MarketData')(sequelize);
 const Message = require('./Message')(sequelize);
 const WatchlistItem = require('./WatchlistItem')(sequelize);
 const NewsItem = require('./NewsItem')(sequelize);
+const Notification = require('./Notification')(sequelize);
 
 // Associations
 User.hasMany(Offer, { foreignKey: 'userId' });
@@ -38,4 +39,5 @@ module.exports = {
   Message,
   WatchlistItem,
   NewsItem,
+  Notification,
 };

--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,0 +1,46 @@
+const EventEmitter = require('events');
+const nodemailer = require('nodemailer');
+
+class NotificationService extends EventEmitter {
+  async sendWebSocket(notification) {
+    this.emit('notification', notification);
+  }
+
+  async sendEmail(to, notification) {
+    try {
+      if (!process.env.SMTP_HOST) {
+        console.log(`Email to ${to}: ${notification.message}`);
+        return;
+      }
+      const transporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port: process.env.SMTP_PORT,
+        auth: {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        },
+      });
+      await transporter.sendMail({
+        from: process.env.SMTP_FROM || 'no-reply@example.com',
+        to,
+        subject: 'FalconTrade Notification',
+        text: notification.message,
+      });
+    } catch (err) {
+      console.error('Failed to send email', err);
+    }
+  }
+
+  async broadcast(notification, users) {
+    await this.sendWebSocket(notification);
+    if (Array.isArray(users)) {
+      for (const user of users) {
+        if (user.email) {
+          await this.sendEmail(user.email, notification);
+        }
+      }
+    }
+  }
+}
+
+module.exports = new NotificationService();


### PR DESCRIPTION
## Summary
- add Notification model, migration, and service for broadcasting alerts
- expose admin endpoints for creating and listing notifications
- allow admins to compose and view notifications from dashboard

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run migrate` *(fails: ERROR)*

------
https://chatgpt.com/codex/tasks/task_e_689edf23dd1c8325a64a2ebde50ba15a