### PR TITLE
chore: use env for email links

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,10 @@ DATABASE_URL=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 STRIPE_PRICE_ID=
-FRONTEND_URL=
+
+# Base URL of the frontend application used in emails
+FRONTEND_URL=http://localhost:3000
+
 JWT_SECRET=
 ALPHAVANTAGE_KEY=
 PORT=

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,3 +17,9 @@ npm run seed
 ```
 
 This loads initial market data from `data/marketData.json` so scheduled refreshes have historical prices to build on.
+
+## Environment Variables
+
+The backend expects configuration via environment variables. Copy `.env.example` to `.env` and provide values. In particular:
+
+- `FRONTEND_URL` — base URL of the frontend application used in verification and password reset emails.

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -25,6 +25,8 @@ const transporter = nodemailer.createTransport({
   },
 });
 
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:3000';
+
 router.post('/signup', authLimiter, async (req, res) => {
   const { username, password, role } = req.body;
   try {
@@ -41,7 +43,7 @@ router.post('/signup', authLimiter, async (req, res) => {
         to: username,
         from: process.env.SMTP_FROM || 'no-reply@falcontrade.com',
         subject: 'Verify your email',
-        text: `Click to verify your email: http://localhost:3000/verify-email?token=${verificationToken}`,
+        text: `Click to verify your email: ${FRONTEND_URL}/verify-email?token=${verificationToken}`,
       });
     } catch (mailErr) {
       console.error('Error sending verification email', mailErr);
@@ -142,7 +144,7 @@ router.post('/forgot-password', authLimiter, async (req, res) => {
         to: email,
         from: process.env.SMTP_FROM || 'no-reply@falcontrade.com',
         subject: 'Password Reset',
-        text: `Reset your password: http://localhost:3000/reset-password?token=${resetToken}`,
+        text: `Reset your password: ${FRONTEND_URL}/reset-password?token=${resetToken}`,
       });
     } catch (mailErr) {
       console.error('Error sending reset email', mailErr);


### PR DESCRIPTION
## Summary
- use `FRONTEND_URL` environment variable when composing auth emails
- document `FRONTEND_URL` and sample value in backend env files

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689ee128f91483258d64df329e265a53