### PR TITLE
Enforce active subscriptions for protected routes

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -30,7 +30,7 @@ async function auth(req, res, next) {
 function requireActiveSubscription(req, res, next) {
   if (
     req.user &&
-    req.user.role === 'subscriber' &&
+    req.user.role !== 'admin' &&
     req.user.subscriptionStatus !== 'active'
   ) {
     return res

--- a/backend/routes/marketData.js
+++ b/backend/routes/marketData.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const auth = require('../middleware/auth');
-const { isAdmin, isSubscriber } = require('../middleware/roles');
+const { isAdmin } = require('../middleware/roles');
 const marketDataController = require('../controllers/marketData');
 
 const router = express.Router();
@@ -8,7 +8,6 @@ const router = express.Router();
 router.get(
   '/:commodity',
   auth,
-  isSubscriber,
   auth.requireActiveSubscription,
   marketDataController.getMarketData
 );

--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const multer = require('multer');
 const auth = require('../middleware/auth');
-const { isAdmin, isSubscriber } = require('../middleware/roles');
+const { isAdmin } = require('../middleware/roles');
 const { Offer } = require('../models');
 const { Op } = require('sequelize');
 
@@ -23,7 +23,6 @@ const upload = multer({
 router.post(
   '/',
   auth,
-  isSubscriber,
   auth.requireActiveSubscription,
   upload.array('attachments'),
   async (req, res) => {
@@ -50,7 +49,7 @@ router.post(
 );
 
 // Get all offers
-router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
+router.get('/', auth, auth.requireActiveSubscription, async (req, res) => {
   const {
     commodity,
     status,
@@ -98,7 +97,7 @@ router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, 
 });
 
 // Get a single offer
-router.get('/:id', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
+router.get('/:id', auth, auth.requireActiveSubscription, async (req, res) => {
   const offer = await Offer.findByPk(req.params.id);
   if (!offer) {
     return res.status(404).json({ message: 'Offer not found' });

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const multer = require('multer');
 const auth = require('../middleware/auth');
-const { isAdmin, isSubscriber } = require('../middleware/roles');
+const { isAdmin } = require('../middleware/roles');
 const { RFQ } = require('../models');
 const { Op } = require('sequelize');
 
@@ -23,7 +23,6 @@ const upload = multer({
 router.post(
   '/',
   auth,
-  isSubscriber,
   auth.requireActiveSubscription,
   upload.array('attachments'),
   async (req, res) => {
@@ -49,7 +48,7 @@ router.post(
 );
 
 // Get all RFQs
-router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
+router.get('/', auth, auth.requireActiveSubscription, async (req, res) => {
   const {
     commodity,
     status,
@@ -89,7 +88,7 @@ router.get('/', auth, isSubscriber, auth.requireActiveSubscription, async (req, 
 });
 
 // Get a single RFQ
-router.get('/:id', auth, isSubscriber, auth.requireActiveSubscription, async (req, res) => {
+router.get('/:id', auth, auth.requireActiveSubscription, async (req, res) => {
   const rfq = await RFQ.findByPk(req.params.id);
   if (!rfq) {
     return res.status(404).json({ message: 'RFQ not found' });

--- a/frontend/components/withAuth.js
+++ b/frontend/components/withAuth.js
@@ -27,7 +27,7 @@ export default function withAuth(Component, requiredRole) {
       } else if (requiredRole && user.role !== requiredRole) {
         router.replace(getDashboard(user.role));
       } else if (
-        user.role === 'subscriber' &&
+        user.role !== 'admin' &&
         user.subscriptionStatus !== 'active'
       ) {
         router.replace('/pricing');
@@ -38,7 +38,7 @@ export default function withAuth(Component, requiredRole) {
       loading ||
       !user ||
       (requiredRole && user.role !== requiredRole) ||
-      (user.role === 'subscriber' && user.subscriptionStatus !== 'active')
+      (user.role !== 'admin' && user.subscriptionStatus !== 'active')
     ) {
       return null;
     }


### PR DESCRIPTION
## Summary
- Block all non-admin users with inactive subscriptions in auth middleware
- Redirect inactive non-admins to pricing in frontend auth helper
- Require active subscriptions for offers, RFQ, and market data API routes

## Testing
- `cd backend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ee37020848325a2b87588278f6cc9