### PR TITLE
Add pricing plans and Stripe checkout redirect

### DIFF
--- a/backend/routes/payments.js
+++ b/backend/routes/payments.js
@@ -5,24 +5,38 @@ const Stripe = require('stripe');
 const router = express.Router();
 const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
 
-router.post('/create-checkout-session', auth, async (req, res) => {
+// Map subscription plans to Stripe price IDs
+const priceMap = {
+  basic: process.env.STRIPE_BASIC_PRICE_ID,
+  pro: process.env.STRIPE_PRO_PRICE_ID,
+};
+
+router.get('/create-checkout-session', auth, async (req, res) => {
   try {
+    const { plan } = req.query;
+    const priceId = priceMap[plan];
+
+    if (!priceId) {
+      return res.status(400).json({ error: 'Invalid plan' });
+    }
+
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
       line_items: [
         {
-          price: process.env.STRIPE_PRICE_ID,
+          price: priceId,
           quantity: 1,
         },
       ],
       success_url: `${process.env.FRONTEND_URL}/success`,
       cancel_url: `${process.env.FRONTEND_URL}/cancel`,
       subscription_data: {
-        metadata: { userId: req.user.id },
+        metadata: { userId: req.user.id, plan },
       },
     });
 
-    res.json({ id: session.id, url: session.url });
+    // Redirect user to Stripe hosted checkout page
+    res.redirect(303, session.url);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/frontend/pages/pricing.js
+++ b/frontend/pages/pricing.js
@@ -1,8 +1,47 @@
+import React from 'react';
+
+const plans = [
+  {
+    name: 'Basic',
+    price: '$10 / month',
+    features: ['Core trading tools', 'Community support'],
+    planId: 'basic',
+  },
+  {
+    name: 'Pro',
+    price: '$30 / month',
+    features: ['Everything in Basic', 'Priority support', 'Advanced analytics'],
+    planId: 'pro',
+  },
+];
+
 export default function Pricing() {
+  const handleSubscribe = (plan) => {
+    window.location.href = `http://localhost:5000/api/v1/payments/create-checkout-session?plan=${plan}`;
+  };
+
   return (
     <div className="p-8">
-      <h1 className="text-2xl mb-4">Pricing</h1>
-      <p>Choose a plan that fits your trading needs.</p>
+      <h1 className="text-3xl font-bold text-center mb-8">Pricing</h1>
+      <div className="grid gap-8 md:grid-cols-2">
+        {plans.map((p) => (
+          <div key={p.planId} className="p-6 border rounded-lg shadow-sm flex flex-col">
+            <h2 className="text-2xl font-semibold mb-4">{p.name}</h2>
+            <p className="text-xl mb-4">{p.price}</p>
+            <ul className="mb-6 list-disc list-inside space-y-1">
+              {p.features.map((f) => (
+                <li key={f}>{f}</li>
+              ))}
+            </ul>
+            <button
+              onClick={() => handleSubscribe(p.planId)}
+              className="mt-auto px-4 py-2 bg-brand text-white rounded-md hover:bg-brand-dark"
+            >
+              Subscribe
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Implement tiered Basic and Pro plans with features and pricing UI
- Add Subscribe buttons that initiate checkout session creation
- Update payments route to create Stripe checkout sessions for selected plan and redirect user to Stripe

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm test` (frontend) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689ee9365ecc83258ae428294db5a4a8