### PR TITLE
Add legal layout for legal pages and update navigation

### DIFF
--- a/frontend/components/LegalLayout.js
+++ b/frontend/components/LegalLayout.js
@@ -1,0 +1,14 @@
+import Head from 'next/head';
+
+export default function LegalLayout({ children, title, description }) {
+  const pageTitle = title ? `${title} | FalconTrade` : 'FalconTrade';
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+        {description && <meta name="description" content={description} />}
+      </Head>
+      <article className="prose dark:prose-invert">{children}</article>
+    </>
+  );
+}

--- a/frontend/components/PublicNav.js
+++ b/frontend/components/PublicNav.js
@@ -12,6 +12,8 @@ export default function PublicNav() {
     { href: '/pricing', label: 'Pricing' },
     { href: '/faq', label: 'FAQ' },
     { href: '/contact', label: 'Contact' },
+    { href: '/privacy', label: 'Privacy' },
+    { href: '/terms', label: 'Terms' },
     { href: '/login', label: 'Login' },
     { href: '/signup', label: 'Sign Up' },
   ];

--- a/frontend/pages/privacy.js
+++ b/frontend/pages/privacy.js
@@ -1,0 +1,13 @@
+import LegalLayout from '../components/LegalLayout';
+
+export default function Privacy() {
+  return (
+    <LegalLayout title="Privacy Policy" description="FalconTrade privacy policy">
+      <h1>Privacy Policy</h1>
+      <p>
+        This Privacy Policy explains how FalconTrade collects, uses, and protects your
+        information. Content will be provided here.
+      </p>
+    </LegalLayout>
+  );
+}

--- a/frontend/pages/terms.js
+++ b/frontend/pages/terms.js
@@ -1,0 +1,13 @@
+import LegalLayout from '../components/LegalLayout';
+
+export default function Terms() {
+  return (
+    <LegalLayout title="Terms of Service" description="FalconTrade terms and conditions">
+      <h1>Terms of Service</h1>
+      <p>
+        These terms and conditions outline the rules and regulations for using FalconTrade.
+        Detailed terms will be provided here.
+      </p>
+    </LegalLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable LegalLayout with meta tags and consistent typography
- add Privacy and Terms pages using LegalLayout
- extend PublicNav to link to Privacy and Terms

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689eed9350748325b80e381928ae9644