### PR TITLE
Use environment-configurable URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 .env
 .env.*
 !backend/.env.example
+!frontend/.env.example
 
 # Local database
 backend/database.sqlite

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Deploy the Express API to [Render](https://render.com):
    - `STRIPE_SECRET_KEY`
    - `STRIPE_WEBHOOK_SECRET`
    - `STRIPE_PRICE_ID`
-   - `FRONTEND_URL`
+   - `FRONTEND_URL` – base URL of the frontend application
    - `JWT_SECRET`
    - `ALPHAVANTAGE_KEY`
    - `PORT` (optional)
@@ -27,7 +27,7 @@ Deploy the Next.js app to [Vercel](https://vercel.com):
 1. Import the repository and select the `frontend` directory.
 2. Set the build command to `npm run build` and the output directory to `.next`.
 3. Configure the following environment variables:
-   - `NEXT_PUBLIC_API_URL`
+   - `NEXT_PUBLIC_API_URL` – base URL of the backend API
    - `NEXT_PUBLIC_STRIPE_PUBLIC_KEY`
 
 Environment variables on Vercel must be prefixed with `NEXT_PUBLIC_` to be accessible in the browser.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,7 @@ STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 STRIPE_PRICE_ID=
 
-# Base URL of the frontend application used in emails
+# Base URL of the frontend application for CORS and emails
 FRONTEND_URL=http://localhost:3000
 
 JWT_SECRET=

--- a/backend/README.md
+++ b/backend/README.md
@@ -22,4 +22,4 @@ This loads initial market data from `data/marketData.json` so scheduled refreshe
 
 The backend expects configuration via environment variables. Copy `.env.example` to `.env` and provide values. In particular:
 
-- `FRONTEND_URL` — base URL of the frontend application used in verification and password reset emails.
+- `FRONTEND_URL` — base URL of the frontend application used in verification and password reset emails and for CORS.

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const path = require('path');
+require('dotenv').config();
 const { sequelize, WatchlistItem, NewsItem } = require('./models');
 const { scheduleMarketDataRefresh } = require('./services/marketDataService');
 
@@ -20,7 +21,7 @@ const contactRoutes = require('./routes/contact');
 const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
-app.use(cors({ origin: 'http://localhost:3000', credentials: true }));
+app.use(cors({ origin: process.env.FRONTEND_URL, credentials: true }));
 app.use(cookieParser());
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Base URL of the backend API
+NEXT_PUBLIC_API_URL=http://localhost:5000
+
+# Stripe publishable key for payments
+NEXT_PUBLIC_STRIPE_PUBLIC_KEY=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,10 @@
 # FalconTrade Frontend
 
 Next.js frontend for FalconTrade platform.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and configure:
+
+- `NEXT_PUBLIC_API_URL` – base URL of the backend API.
+- `NEXT_PUBLIC_STRIPE_PUBLIC_KEY` – Stripe publishable key.

--- a/frontend/contexts/AuthContext.js
+++ b/frontend/contexts/AuthContext.js
@@ -9,7 +9,7 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const res = await fetch('http://localhost:5000/api/v1/auth/me', {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/me`, {
           credentials: 'include',
         });
         if (res.ok) {

--- a/frontend/pages/admin/index.js
+++ b/frontend/pages/admin/index.js
@@ -13,7 +13,7 @@ function AdminDashboard() {
   useEffect(() => {
     const fetchMetrics = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/v1/admin/metrics', {
+        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/metrics`, {
           withCredentials: true,
         });
         setMetrics(res.data);
@@ -24,7 +24,7 @@ function AdminDashboard() {
 
     const fetchNotifications = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/v1/admin/notifications', {
+        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/notifications`, {
           withCredentials: true,
         });
         setNotifications(res.data);
@@ -43,7 +43,7 @@ function AdminDashboard() {
     e.preventDefault();
     try {
       const res = await axios.post(
-        'http://localhost:5000/api/v1/admin/notifications',
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/notifications`,
         { message, targetRoles: roles },
         { withCredentials: true },
       );

--- a/frontend/pages/admin/offers.js
+++ b/frontend/pages/admin/offers.js
@@ -7,7 +7,7 @@ function AdminOffers() {
 
   const fetchOffers = async () => {
     try {
-      const res = await axios.get('http://localhost:5000/api/v1/admin/listings', {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/listings`, {
         withCredentials: true,
       });
       setOffers(res.data.offers || res.data);
@@ -23,7 +23,7 @@ function AdminOffers() {
   const approve = async (id) => {
     try {
       await axios.post(
-        `http://localhost:5000/api/v1/admin/listings/${id}/approve`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/listings/${id}/approve`,
         {},
         { withCredentials: true }
       );
@@ -36,7 +36,7 @@ function AdminOffers() {
   const remove = async (id) => {
     try {
       await axios.delete(
-        `http://localhost:5000/api/v1/admin/listings/${id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/listings/${id}`,
         { withCredentials: true }
       );
       fetchOffers();
@@ -48,7 +48,7 @@ function AdminOffers() {
   const reject = async (id) => {
     try {
       await axios.post(
-        `http://localhost:5000/api/v1/admin/listings/${id}/reject`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/listings/${id}/reject`,
         {},
         { withCredentials: true }
       );

--- a/frontend/pages/admin/reports.js
+++ b/frontend/pages/admin/reports.js
@@ -8,7 +8,7 @@ function AdminReports() {
   useEffect(() => {
     const fetchRevenue = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/v1/admin/revenue', {
+        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/revenue`, {
           withCredentials: true,
         });
         setRevenue(res.data.revenue);

--- a/frontend/pages/admin/rfqs.js
+++ b/frontend/pages/admin/rfqs.js
@@ -7,7 +7,7 @@ function AdminRFQs() {
 
   const fetchRFQs = async () => {
     try {
-      const res = await axios.get('http://localhost:5000/api/v1/admin/rfqs', {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/rfqs`, {
         withCredentials: true,
       });
       setRfqs(res.data);
@@ -23,7 +23,7 @@ function AdminRFQs() {
   const approve = async (id) => {
     try {
       await axios.post(
-        `http://localhost:5000/api/v1/admin/rfqs/${id}/approve`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/rfqs/${id}/approve`,
         {},
         { withCredentials: true }
       );
@@ -36,7 +36,7 @@ function AdminRFQs() {
   const reject = async (id) => {
     try {
       await axios.post(
-        `http://localhost:5000/api/v1/admin/rfqs/${id}/reject`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/rfqs/${id}/reject`,
         {},
         { withCredentials: true }
       );

--- a/frontend/pages/admin/users.js
+++ b/frontend/pages/admin/users.js
@@ -7,7 +7,7 @@ function AdminUsers() {
 
   const fetchUsers = async () => {
     try {
-      const res = await axios.get('http://localhost:5000/api/v1/admin/users', {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/users`, {
         withCredentials: true,
       });
       setUsers(res.data);
@@ -35,7 +35,7 @@ function AdminUsers() {
   const handleUpdate = async (user) => {
     try {
       await axios.put(
-        `http://localhost:5000/api/v1/admin/users/${user.id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/users/${user.id}`,
         {
           role: user.role,
           subscriptionStatus: user.subscriptionStatus,
@@ -51,7 +51,7 @@ function AdminUsers() {
   const block = async (id) => {
     try {
       await axios.post(
-        `http://localhost:5000/api/v1/admin/users/${id}/block`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/users/${id}/block`,
         {},
         { withCredentials: true },
       );
@@ -64,7 +64,7 @@ function AdminUsers() {
   const approve = async (id) => {
     try {
       await axios.post(
-        `http://localhost:5000/api/v1/admin/users/${id}/approve`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/users/${id}/approve`,
         {},
         { withCredentials: true },
       );

--- a/frontend/pages/buyer/dashboard.js
+++ b/frontend/pages/buyer/dashboard.js
@@ -9,7 +9,7 @@ function BuyerDashboard() {
   useEffect(() => {
     const fetchOffers = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/v1/offers', {
+        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`, {
           withCredentials: true,
         });
         setOffers(res.data);

--- a/frontend/pages/contact.js
+++ b/frontend/pages/contact.js
@@ -22,7 +22,7 @@ export default function Contact() {
       formData.append('file', file);
     }
     try {
-      await axios.post('http://localhost:5000/api/v1/contact', formData, {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/contact`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       setStatus('Message sent successfully.');

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -31,13 +31,13 @@ function Dashboard() {
       setLoadingWatchlist(true);
       try {
         const [watchlistRes, newsRes, symbolsRes] = await Promise.all([
-          axios.get('http://localhost:5000/api/v1/watchlist', {
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/watchlist`, {
             withCredentials: true,
           }),
-          axios.get('http://localhost:5000/api/v1/news', {
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/news`, {
             withCredentials: true,
           }),
-          axios.get('http://localhost:5000/api/v1/market-data', {
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/market-data`, {
             withCredentials: true,
           }),
         ]);
@@ -60,11 +60,11 @@ function Dashboard() {
       setLoadingForecast(true);
       try {
         const forecastRes = await axios.get(
-          `http://localhost:5000/api/v1/forecast/${selectedSymbol}`,
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/forecast/${selectedSymbol}`,
           { withCredentials: true }
         );
         const marketRes = await axios.get(
-          `http://localhost:5000/api/v1/marketData/${selectedSymbol}`,
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/marketData/${selectedSymbol}`,
           { withCredentials: true }
         );
         setMarketInfo(marketRes.data);

--- a/frontend/pages/forgot-password.js
+++ b/frontend/pages/forgot-password.js
@@ -8,7 +8,7 @@ export default function ForgotPassword() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await axios.post('http://localhost:5000/api/v1/auth/forgot-password', {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/forgot-password`, {
         email,
       });
       setMessage('Check your email for a reset link.');

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -13,7 +13,7 @@ export default function Login() {
     e.preventDefault();
     try {
       const res = await axios.post(
-        'http://localhost:5000/api/v1/auth/login',
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/login`,
         { username, password },
         { withCredentials: true }
       );

--- a/frontend/pages/messages.js
+++ b/frontend/pages/messages.js
@@ -16,7 +16,7 @@ function Messages() {
 
   const fetchMessages = async () => {
     try {
-      const res = await axios.get('http://localhost:5000/api/v1/messages', {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/messages`, {
         withCredentials: true,
       });
       setMessages(res.data);
@@ -50,7 +50,7 @@ function Messages() {
       if (offerId) formData.append('offerId', offerId);
       if (rfqId) formData.append('rfqId', rfqId);
       files.forEach((file) => formData.append('attachments', file));
-      await axios.post('http://localhost:5000/api/v1/messages', formData, {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/messages`, formData, {
         withCredentials: true,
         headers: {
           'Content-Type': 'multipart/form-data',
@@ -109,14 +109,14 @@ function Messages() {
                     att.mimetype && att.mimetype.startsWith('image/') ? (
                       <img
                         key={idx}
-                        src={`http://localhost:5000${att.url}`}
+                        src={`${process.env.NEXT_PUBLIC_API_URL}${att.url}`}
                         alt={att.originalname}
                         className="max-w-xs mt-2"
                       />
                     ) : (
                       <a
                         key={idx}
-                        href={`http://localhost:5000${att.url}`}
+                        href={`${process.env.NEXT_PUBLIC_API_URL}${att.url}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-blue-600 underline block mt-2"

--- a/frontend/pages/offers/[id].js
+++ b/frontend/pages/offers/[id].js
@@ -15,7 +15,7 @@ function OfferDetail() {
 
   const fetchOffer = async () => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/v1/offers/${id}`, {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers/${id}`, {
         withCredentials: true,
       });
       setOffer(res.data);
@@ -27,7 +27,7 @@ function OfferDetail() {
   const fetchMessages = async () => {
     try {
       const res = await axios.get(
-        `http://localhost:5000/api/v1/messages?offerId=${id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/messages?offerId=${id}`,
         { withCredentials: true }
       );
       setMessages(res.data);
@@ -55,7 +55,7 @@ function OfferDetail() {
       formData.append('content', content);
       formData.append('offerId', id);
       files.forEach((file) => formData.append('attachments', file));
-      await axios.post('http://localhost:5000/api/v1/messages', formData, {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/messages`, formData, {
         withCredentials: true,
         headers: {
           'Content-Type': 'multipart/form-data',
@@ -89,14 +89,14 @@ function OfferDetail() {
                 att.mimetype && att.mimetype.startsWith('image/') ? (
                   <img
                     key={idx}
-                    src={`http://localhost:5000${att.url}`}
+                    src={`${process.env.NEXT_PUBLIC_API_URL}${att.url}`}
                     alt={att.originalname}
                     className="max-w-xs mt-2"
                   />
                 ) : (
                   <a
                     key={idx}
-                    href={`http://localhost:5000${att.url}`}
+                    href={`${process.env.NEXT_PUBLIC_API_URL}${att.url}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 underline block mt-2"

--- a/frontend/pages/offers/index.js
+++ b/frontend/pages/offers/index.js
@@ -29,7 +29,7 @@ function Offers() {
         params.sortBy = sortBy;
         params.order = order;
       }
-      const res = await axios.get('http://localhost:5000/api/v1/offers', {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`, {
         params,
         withCredentials: true,
       });

--- a/frontend/pages/offers/new.js
+++ b/frontend/pages/offers/new.js
@@ -22,7 +22,7 @@ function NewOffer() {
       formData.append('price', price);
       formData.append('quantity', quantity);
       files.forEach((file) => formData.append('attachments', file));
-      await axios.post('http://localhost:5000/api/v1/offers', formData, {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`, formData, {
         withCredentials: true,
         headers: { 'Content-Type': 'multipart/form-data' },
       });

--- a/frontend/pages/pricing.js
+++ b/frontend/pages/pricing.js
@@ -17,7 +17,7 @@ const plans = [
 
 export default function Pricing() {
   const handleSubscribe = (plan) => {
-    window.location.href = `http://localhost:5000/api/v1/payments/create-checkout-session?plan=${plan}`;
+    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/payments/create-checkout-session?plan=${plan}`;
   };
 
   return (

--- a/frontend/pages/profile.js
+++ b/frontend/pages/profile.js
@@ -14,7 +14,7 @@ function Profile() {
     if (!user) return;
     const fetchProfile = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/v1/users/me', {
+        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/me`, {
           withCredentials: true,
         });
         setCompanyName(res.data.companyName || '');
@@ -37,7 +37,7 @@ function Profile() {
         formData.append('logo', logo);
       }
       const res = await axios.put(
-        'http://localhost:5000/api/v1/users/me',
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/users/me`,
         formData,
         {
           withCredentials: true,
@@ -68,7 +68,7 @@ function Profile() {
         />
         {logoUrl && (
           <img
-            src={`http://localhost:5000${logoUrl}`}
+            src={`${process.env.NEXT_PUBLIC_API_URL}${logoUrl}`}
             alt="Company Logo"
             className="h-24"
           />

--- a/frontend/pages/reset-password.js
+++ b/frontend/pages/reset-password.js
@@ -11,7 +11,7 @@ export default function ResetPassword() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await axios.post('http://localhost:5000/api/v1/auth/reset-password', {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/reset-password`, {
         token,
         password,
       });

--- a/frontend/pages/rfqs/[id].js
+++ b/frontend/pages/rfqs/[id].js
@@ -15,7 +15,7 @@ function RFQDetail() {
 
   const fetchRfq = async () => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/v1/rfqs/${id}`, {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs/${id}`, {
         withCredentials: true,
       });
       setRfq(res.data);
@@ -27,7 +27,7 @@ function RFQDetail() {
   const fetchMessages = async () => {
     try {
       const res = await axios.get(
-        `http://localhost:5000/api/v1/messages?rfqId=${id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/messages?rfqId=${id}`,
         { withCredentials: true }
       );
       setMessages(res.data);
@@ -55,7 +55,7 @@ function RFQDetail() {
       formData.append('content', content);
       formData.append('rfqId', id);
       files.forEach((file) => formData.append('attachments', file));
-      await axios.post('http://localhost:5000/api/v1/messages', formData, {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/messages`, formData, {
         withCredentials: true,
         headers: {
           'Content-Type': 'multipart/form-data',
@@ -88,14 +88,14 @@ function RFQDetail() {
                 att.mimetype && att.mimetype.startsWith('image/') ? (
                   <img
                     key={idx}
-                    src={`http://localhost:5000${att.url}`}
+                    src={`${process.env.NEXT_PUBLIC_API_URL}${att.url}`}
                     alt={att.originalname}
                     className="max-w-xs mt-2"
                   />
                 ) : (
                   <a
                     key={idx}
-                    href={`http://localhost:5000${att.url}`}
+                    href={`${process.env.NEXT_PUBLIC_API_URL}${att.url}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 underline block mt-2"

--- a/frontend/pages/rfqs/index.js
+++ b/frontend/pages/rfqs/index.js
@@ -25,7 +25,7 @@ function RFQs() {
         params.sortBy = sortBy;
         params.order = order;
       }
-      const res = await axios.get('http://localhost:5000/api/v1/rfqs', {
+      const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`, {
         params,
         withCredentials: true,
       });

--- a/frontend/pages/rfqs/new.js
+++ b/frontend/pages/rfqs/new.js
@@ -20,7 +20,7 @@ function NewRFQ() {
       formData.append('symbol', symbol);
       formData.append('quantity', quantity);
       files.forEach((file) => formData.append('attachments', file));
-      await axios.post('http://localhost:5000/api/v1/rfqs', formData, {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`, formData, {
         withCredentials: true,
         headers: { 'Content-Type': 'multipart/form-data' },
       });

--- a/frontend/pages/seller/dashboard.js
+++ b/frontend/pages/seller/dashboard.js
@@ -9,7 +9,7 @@ function SellerDashboard() {
   useEffect(() => {
     const fetchRfqs = async () => {
       try {
-        const res = await axios.get('http://localhost:5000/api/v1/rfqs', {
+        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`, {
           withCredentials: true,
         });
         setRfqs(res.data);

--- a/frontend/pages/signup.js
+++ b/frontend/pages/signup.js
@@ -9,7 +9,7 @@ export default function Signup() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await fetch('http://localhost:5000/api/v1/auth/signup', {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/signup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password, role }),

--- a/frontend/pages/verify-email.js
+++ b/frontend/pages/verify-email.js
@@ -12,7 +12,7 @@ export default function VerifyEmail() {
     const verify = async () => {
       try {
         await axios.get(
-          `http://localhost:5000/api/v1/auth/verify-email?token=${token}`
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/verify-email?token=${token}`
         );
         setMessage('Email verified successfully.');
       } catch (err) {


### PR DESCRIPTION
## Summary
- use NEXT_PUBLIC_API_URL for all frontend API requests
- load CORS origin from FRONTEND_URL and read env vars
- document NEXT_PUBLIC_API_URL and FRONTEND_URL in env examples and deployment docs

## Testing
- `cd backend && npm test` (fails: Missing script: "test")
- `cd ../frontend && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689f08321b8883258eddba7bc11a465e