### PR TITLE
Add robust error handling across backend and frontend

### DIFF
--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -48,112 +48,140 @@ router.post(
 );
 
 // Get all RFQs
-router.get('/', auth, auth.requireActiveSubscription, async (req, res) => {
-  const {
-    commodity,
-    status,
-    sortBy,
-    order,
-    minQuantity,
-    maxQuantity,
-    location,
-  } = req.query;
+router.get('/', auth, auth.requireActiveSubscription, async (req, res, next) => {
+  try {
+    const {
+      commodity,
+      status,
+      sortBy,
+      order,
+      minQuantity,
+      maxQuantity,
+      location,
+    } = req.query;
 
-  const where = {};
+    const where = {};
 
-  if (commodity) {
-    where.symbol = { [Op.iLike]: `%${commodity}%` };
+    if (commodity) {
+      where.symbol = { [Op.iLike]: `%${commodity}%` };
+    }
+
+    if (status) where.status = status;
+
+    if (location) {
+      where.location = { [Op.iLike]: `%${location}%` };
+    }
+
+    if (minQuantity || maxQuantity) {
+      where.quantity = {};
+      if (minQuantity) where.quantity[Op.gte] = parseInt(minQuantity, 10);
+      if (maxQuantity) where.quantity[Op.lte] = parseInt(maxQuantity, 10);
+    }
+
+    const options = { where };
+    if (sortBy) {
+      options.order = [
+        [sortBy, order && order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC'],
+      ];
+    }
+    const rfqs = await RFQ.findAll(options);
+    res.json(rfqs);
+  } catch (err) {
+    next(err);
   }
-
-  if (status) where.status = status;
-
-  if (location) {
-    where.location = { [Op.iLike]: `%${location}%` };
-  }
-
-  if (minQuantity || maxQuantity) {
-    where.quantity = {};
-    if (minQuantity) where.quantity[Op.gte] = parseInt(minQuantity, 10);
-    if (maxQuantity) where.quantity[Op.lte] = parseInt(maxQuantity, 10);
-  }
-
-  const options = { where };
-  if (sortBy) {
-    options.order = [
-      [sortBy, order && order.toUpperCase() === 'DESC' ? 'DESC' : 'ASC'],
-    ];
-  }
-  const rfqs = await RFQ.findAll(options);
-  res.json(rfqs);
 });
 
 // Get a single RFQ
-router.get('/:id', auth, auth.requireActiveSubscription, async (req, res) => {
-  const rfq = await RFQ.findByPk(req.params.id);
-  if (!rfq) {
-    return res.status(404).json({ message: 'RFQ not found' });
+router.get('/:id', auth, auth.requireActiveSubscription, async (req, res, next) => {
+  try {
+    const rfq = await RFQ.findByPk(req.params.id);
+    if (!rfq) {
+      return res.status(404).json({ message: 'RFQ not found' });
+    }
+    res.json(rfq);
+  } catch (err) {
+    next(err);
   }
-  res.json(rfq);
 });
 
 // Update an RFQ (admin only)
-router.put('/:id', auth, isAdmin, async (req, res) => {
-  const rfq = await RFQ.findByPk(req.params.id);
-  if (!rfq) {
-    return res.status(404).json({ message: 'RFQ not found' });
+router.put('/:id', auth, isAdmin, async (req, res, next) => {
+  try {
+    const rfq = await RFQ.findByPk(req.params.id);
+    if (!rfq) {
+      return res.status(404).json({ message: 'RFQ not found' });
+    }
+    await rfq.update(req.body);
+    res.json(rfq);
+  } catch (err) {
+    next(err);
   }
-  await rfq.update(req.body);
-  res.json(rfq);
 });
 
 // Delete an RFQ (admin only)
-router.delete('/:id', auth, isAdmin, async (req, res) => {
-  const rfq = await RFQ.findByPk(req.params.id);
-  if (!rfq) {
-    return res.status(404).json({ message: 'RFQ not found' });
+router.delete('/:id', auth, isAdmin, async (req, res, next) => {
+  try {
+    const rfq = await RFQ.findByPk(req.params.id);
+    if (!rfq) {
+      return res.status(404).json({ message: 'RFQ not found' });
+    }
+    await rfq.destroy();
+    res.json({ message: 'RFQ deleted' });
+  } catch (err) {
+    next(err);
   }
-  await rfq.destroy();
-  res.json({ message: 'RFQ deleted' });
 });
 
 // Approve an RFQ (admin only)
-router.post('/:id/approve', auth, isAdmin, async (req, res) => {
-  const rfq = await RFQ.findByPk(req.params.id);
-  if (!rfq) {
-    return res.status(404).json({ message: 'RFQ not found' });
+router.post('/:id/approve', auth, isAdmin, async (req, res, next) => {
+  try {
+    const rfq = await RFQ.findByPk(req.params.id);
+    if (!rfq) {
+      return res.status(404).json({ message: 'RFQ not found' });
+    }
+    rfq.status = 'approved';
+    await rfq.save();
+    res.json(rfq);
+  } catch (err) {
+    next(err);
   }
-  rfq.status = 'approved';
-  await rfq.save();
-  res.json(rfq);
 });
 
 // Feature an RFQ (admin only)
-router.post('/:id/feature', auth, isAdmin, async (req, res) => {
-  const rfq = await RFQ.findByPk(req.params.id);
-  if (!rfq) {
-    return res.status(404).json({ message: 'RFQ not found' });
+router.post('/:id/feature', auth, isAdmin, async (req, res, next) => {
+  try {
+    const rfq = await RFQ.findByPk(req.params.id);
+    if (!rfq) {
+      return res.status(404).json({ message: 'RFQ not found' });
+    }
+    rfq.status = 'featured';
+    await rfq.save();
+    res.json(rfq);
+  } catch (err) {
+    next(err);
   }
-  rfq.status = 'featured';
-  await rfq.save();
-  res.json(rfq);
 });
 
 // Update order status (owner only)
-router.post('/:id/status', auth, async (req, res) => {
-  const { orderStatus } = req.body;
-  if (!['pending', 'shipped', 'completed'].includes(orderStatus)) {
-    return res.status(400).json({ message: 'Invalid order status' });
+router.post('/:id/status', auth, async (req, res, next) => {
+  try {
+    const { orderStatus } = req.body;
+    if (!['pending', 'shipped', 'completed'].includes(orderStatus)) {
+      return res.status(400).json({ message: 'Invalid order status' });
+    }
+    const rfq = await RFQ.findByPk(req.params.id);
+    if (!rfq) {
+      return res.status(404).json({ message: 'RFQ not found' });
+    }
+    if (rfq.userId !== req.user.id) {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
+    rfq.orderStatus = orderStatus;
+    await rfq.save();
+    res.json(rfq);
+  } catch (err) {
+    next(err);
   }
-  const rfq = await RFQ.findByPk(req.params.id);
-  if (!rfq) {
-    return res.status(404).json({ message: 'RFQ not found' });
-  }
-  if (rfq.userId !== req.user.id) {
-    return res.status(403).json({ message: 'Not authorized' });
-  }
-  rfq.orderStatus = orderStatus;
-  await rfq.save();
-  res.json(rfq);
 });
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -46,6 +46,14 @@ app.get('/', (req, res) => {
   res.send('FalconTrade Backend is running');
 });
 
+// Global error handler
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(err.status || 500).json({
+    error: err.message || 'Internal Server Error',
+  });
+});
+
 const PORT = process.env.PORT || 5000;
 sequelize.sync().then(async () => {
   if (await WatchlistItem.count() === 0) {

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,4 +1,6 @@
 import '../styles/globals.css';
+import { useEffect } from 'react';
+import axios from 'axios';
 import { AuthProvider, useAuth } from '../contexts/AuthContext';
 import ThemeToggle from '../components/ThemeToggle';
 import PublicNav from '../components/PublicNav';
@@ -6,6 +8,22 @@ import Layout from '../components/Layout';
 
 function AppContent({ Component, pageProps }) {
   const { user } = useAuth();
+
+  useEffect(() => {
+    const interceptor = axios.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (typeof window !== 'undefined') {
+          alert(
+            error.response?.data?.error || 'An unexpected error occurred'
+          );
+        }
+        return Promise.reject(error);
+      }
+    );
+    return () => axios.interceptors.response.eject(interceptor);
+  }, []);
+
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 text-black dark:text-white">
       <ThemeToggle />


### PR DESCRIPTION
## Summary
- wrap offer and RFQ routes in try/catch and delegate errors to global handler
- add global Express error handler for consistent 500 responses
- surface API errors in frontend via Axios response interceptor

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f11190540832593111ccbc84548fd