### PR TITLE
Add editable content pages and backend support

### DIFF
--- a/backend/migrations/20240901000014-create-contents.js
+++ b/backend/migrations/20240901000014-create-contents.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Contents', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      slug: { type: Sequelize.STRING, allowNull: false, unique: true },
+      body: { type: Sequelize.TEXT, allowNull: false },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('Contents');
+  },
+};

--- a/backend/models/Content.js
+++ b/backend/models/Content.js
@@ -1,0 +1,10 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const Content = sequelize.define('Content', {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    slug: { type: DataTypes.STRING, allowNull: false, unique: true },
+    body: { type: DataTypes.TEXT, allowNull: false },
+  });
+  return Content;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -8,6 +8,7 @@ const Message = require('./Message')(sequelize);
 const WatchlistItem = require('./WatchlistItem')(sequelize);
 const NewsItem = require('./NewsItem')(sequelize);
 const Notification = require('./Notification')(sequelize);
+const Content = require('./Content')(sequelize);
 
 // Associations
 User.hasMany(Offer, { foreignKey: 'userId' });
@@ -40,4 +41,5 @@ module.exports = {
   WatchlistItem,
   NewsItem,
   Notification,
+  Content,
 };

--- a/backend/routes/content.js
+++ b/backend/routes/content.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const auth = require('../middleware/auth');
+const { isAdmin } = require('../middleware/roles');
+const { Content } = require('../models');
+
+const router = express.Router();
+
+// Get content by slug
+router.get('/:slug', async (req, res) => {
+  const item = await Content.findOne({ where: { slug: req.params.slug } });
+  if (!item) {
+    return res.status(404).json({ message: 'Content not found' });
+  }
+  return res.json(item);
+});
+
+// Upsert content by slug (admin only)
+router.put('/:slug', auth, isAdmin, async (req, res) => {
+  const { body } = req.body;
+  let item = await Content.findOne({ where: { slug: req.params.slug } });
+  if (item) {
+    await item.update({ body });
+  } else {
+    item = await Content.create({ slug: req.params.slug, body });
+  }
+  return res.json(item);
+});
+
+module.exports = router;

--- a/backend/seeders/20240901000008-demo-content.js
+++ b/backend/seeders/20240901000008-demo-content.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.bulkInsert('Contents', [
+      {
+        slug: 'about',
+        body: 'FalconTrade helps you stay informed and manage your investments with ease.',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        slug: 'faq',
+        body: 'Find answers to common questions about FalconTrade.',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('Contents', { slug: ['about', 'faq'] });
+  },
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,7 @@ const adminRoutes = require('./routes/admin');
 const userRoutes = require('./routes/users');
 const forecastRoutes = require('./routes/forecast');
 const contactRoutes = require('./routes/contact');
+const contentRoutes = require('./routes/content');
 const stripeWebhook = require('./webhooks/stripe');
 
 const app = express();
@@ -40,6 +41,7 @@ app.use('/api/v1/messages', messageRoutes);
   app.use('/api/v1/admin', adminRoutes);
   app.use('/api/v1/users', userRoutes);
   app.use('/api/v1/contact', contactRoutes);
+  app.use('/api/v1/content', contentRoutes);
 
 app.get('/', (req, res) => {
   res.send('FalconTrade Backend is running');

--- a/frontend/pages/about.js
+++ b/frontend/pages/about.js
@@ -1,8 +1,71 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
 export default function About() {
+  const { user } = useAuth();
+  const [content, setContent] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const [editing, setEditing] = useState(false);
+
+  useEffect(() => {
+    const fetchContent = async () => {
+      try {
+        const res = await fetch('http://localhost:5000/api/v1/content/about');
+        if (res.ok) {
+          const data = await res.json();
+          setContent(data.body);
+          setEditContent(data.body);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchContent();
+  }, []);
+
+  const saveContent = async () => {
+    try {
+      const res = await fetch('http://localhost:5000/api/v1/content/about', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ body: editContent }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setContent(data.body);
+        setEditing(false);
+      } else {
+        alert('Failed to save');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="p-8">
       <h1 className="text-2xl mb-4">About FalconTrade</h1>
-      <p>FalconTrade helps you stay informed and manage your investments with ease.</p>
+      {editing ? (
+        <div>
+          <textarea
+            className="w-full border p-2 mb-2"
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+          />
+          <button className="mr-2" onClick={saveContent}>
+            Save
+          </button>
+          <button onClick={() => setEditing(false)}>Cancel</button>
+        </div>
+      ) : (
+        <p>{content}</p>
+      )}
+      {user && user.role === 'admin' && !editing && (
+        <button className="mt-4" onClick={() => setEditing(true)}>
+          Edit
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/pages/faq.js
+++ b/frontend/pages/faq.js
@@ -1,8 +1,71 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
 export default function FAQ() {
+  const { user } = useAuth();
+  const [content, setContent] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const [editing, setEditing] = useState(false);
+
+  useEffect(() => {
+    const fetchContent = async () => {
+      try {
+        const res = await fetch('http://localhost:5000/api/v1/content/faq');
+        if (res.ok) {
+          const data = await res.json();
+          setContent(data.body);
+          setEditContent(data.body);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchContent();
+  }, []);
+
+  const saveContent = async () => {
+    try {
+      const res = await fetch('http://localhost:5000/api/v1/content/faq', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ body: editContent }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setContent(data.body);
+        setEditing(false);
+      } else {
+        alert('Failed to save');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="p-8">
       <h1 className="text-2xl mb-4">Frequently Asked Questions</h1>
-      <p>Find answers to common questions about FalconTrade.</p>
+      {editing ? (
+        <div>
+          <textarea
+            className="w-full border p-2 mb-2"
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+          />
+          <button className="mr-2" onClick={saveContent}>
+            Save
+          </button>
+          <button onClick={() => setEditing(false)}>Cancel</button>
+        </div>
+      ) : (
+        <p>{content}</p>
+      )}
+      {user && user.role === 'admin' && !editing && (
+        <button className="mt-4" onClick={() => setEditing(true)}>
+          Edit
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Content model, migrations, and seed data for about/faq pages
- expose GET/PUT `/api/v1/content/:slug` endpoints to read/update page copy
- load and allow admins to edit About and FAQ content on the frontend

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689eeab0cec883258ed283fe7142a4c9