### PR TITLE
feat: extend admin dashboard and routes

### DIFF
--- a/backend/controllers/admin.js
+++ b/backend/controllers/admin.js
@@ -1,4 +1,5 @@
 const { User, Offer, RFQ, sequelize } = require('../models');
+const { Op } = require('sequelize');
 const Stripe = require('stripe');
 
 const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
@@ -248,6 +249,29 @@ async function getStripeRevenue(req, res) {
   }
 }
 
+async function getTransactions(req, res) {
+  try {
+    const activeOffers = await Offer.findAll({
+      where: { orderStatus: { [Op.ne]: 'completed' } },
+    });
+    const pastOffers = await Offer.findAll({
+      where: { orderStatus: 'completed' },
+    });
+    const activeRFQs = await RFQ.findAll({
+      where: { orderStatus: { [Op.ne]: 'completed' } },
+    });
+    const pastRFQs = await RFQ.findAll({
+      where: { orderStatus: 'completed' },
+    });
+    res.json({
+      active: { offers: activeOffers, rfqs: activeRFQs },
+      past: { offers: pastOffers, rfqs: pastRFQs },
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
 module.exports = {
   getMetrics,
   getUsers,
@@ -263,5 +287,6 @@ module.exports = {
   approveRFQ,
   rejectRFQ,
   getStripeRevenue,
+  getTransactions,
 };
 

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -16,6 +16,7 @@ const {
   approveRFQ,
   rejectRFQ,
   getStripeRevenue,
+  getTransactions,
 } = require('../controllers/admin');
 const { Notification, User } = require('../models');
 const notificationService = require('../services/notificationService');
@@ -36,6 +37,7 @@ router.get('/rfqs', auth, isAdmin, getRFQs);
 router.post('/rfqs/:id/approve', auth, isAdmin, approveRFQ);
 router.post('/rfqs/:id/reject', auth, isAdmin, rejectRFQ);
 router.get('/revenue', auth, isAdmin, getStripeRevenue);
+router.get('/transactions', auth, isAdmin, getTransactions);
 
 // Notifications
 router.post('/notifications', auth, isAdmin, async (req, res) => {

--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -19,11 +19,19 @@ const upload = multer({
   }),
 });
 
+// Allow admins to bypass subscription requirement
+const requireSubscriptionOrAdmin = (req, res, next) => {
+  if (req.user && req.user.role === 'admin') {
+    return next();
+  }
+  return auth.requireActiveSubscription(req, res, next);
+};
+
 // Create a new offer
 router.post(
   '/',
   auth,
-  auth.requireActiveSubscription,
+  requireSubscriptionOrAdmin,
   upload.array('attachments'),
   async (req, res) => {
     try {

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -19,11 +19,19 @@ const upload = multer({
   }),
 });
 
+// Allow admins to bypass subscription requirement
+const requireSubscriptionOrAdmin = (req, res, next) => {
+  if (req.user && req.user.role === 'admin') {
+    return next();
+  }
+  return auth.requireActiveSubscription(req, res, next);
+};
+
 // Create a new RFQ
 router.post(
   '/',
   auth,
-  auth.requireActiveSubscription,
+  requireSubscriptionOrAdmin,
   upload.array('attachments'),
   async (req, res) => {
     try {

--- a/frontend/pages/admin/index.js
+++ b/frontend/pages/admin/index.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import Link from 'next/link';
 import { useAuth } from '../../contexts/AuthContext';
 import withAuth from '../../components/withAuth';
 
@@ -60,6 +61,20 @@ function AdminDashboard() {
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Admin Dashboard</h1>
+      <div className="mb-4 space-x-4">
+        <Link href="/admin/users" className="text-blue-500 underline">
+          Users
+        </Link>
+        <Link href="/admin/offers" className="text-blue-500 underline">
+          Offers
+        </Link>
+        <Link href="/admin/rfqs" className="text-blue-500 underline">
+          RFQs
+        </Link>
+        <Link href="/admin/transactions" className="text-blue-500 underline">
+          Transactions
+        </Link>
+      </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="p-4 border rounded">
           <h2 className="text-xl">Users</h2>

--- a/frontend/pages/admin/offers.js
+++ b/frontend/pages/admin/offers.js
@@ -4,6 +4,9 @@ import withAuth from '../../components/withAuth';
 
 function AdminOffers() {
   const [offers, setOffers] = useState([]);
+  const [symbol, setSymbol] = useState('');
+  const [price, setPrice] = useState('');
+  const [quantity, setQuantity] = useState('');
 
   const fetchOffers = async () => {
     try {
@@ -14,7 +17,7 @@ function AdminOffers() {
     } catch (err) {
       console.error(err);
     }
-  };
+  }; 
 
   useEffect(() => {
     fetchOffers();
@@ -26,6 +29,47 @@ function AdminOffers() {
         `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/listings/${id}/approve`,
         {},
         { withCredentials: true }
+      );
+      fetchOffers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const create = async (e) => {
+    e.preventDefault();
+    try {
+      const formData = new FormData();
+      formData.append('symbol', symbol);
+      formData.append('price', price);
+      formData.append('quantity', quantity);
+      await axios.post(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`,
+        formData,
+        {
+          withCredentials: true,
+          headers: { 'Content-Type': 'multipart/form-data' },
+        },
+      );
+      setSymbol('');
+      setPrice('');
+      setQuantity('');
+      fetchOffers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const edit = async (offer) => {
+    const newPrice = prompt('New price', offer.price);
+    if (newPrice === null) return;
+    const newQuantity = prompt('New quantity', offer.quantity);
+    if (newQuantity === null) return;
+    try {
+      await axios.put(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers/${offer.id}`,
+        { price: newPrice, quantity: newQuantity },
+        { withCredentials: true },
       );
       fetchOffers();
     } catch (err) {
@@ -61,6 +105,29 @@ function AdminOffers() {
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Manage Offers</h1>
+      <form onSubmit={create} className="mb-4 space-x-2">
+        <input
+          className="border p-1"
+          placeholder="Commodity"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+        />
+        <input
+          className="border p-1"
+          placeholder="Price"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+        />
+        <input
+          className="border p-1"
+          placeholder="Quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-2 py-1" type="submit">
+          Add
+        </button>
+      </form>
       <ul>
         {offers.map((offer) => (
           <li key={offer.id} className="border p-2 mb-2">
@@ -82,6 +149,12 @@ function AdminOffers() {
                   </button>
                 </>
               )}
+              <button
+                className="bg-blue-500 text-white px-2 py-1"
+                onClick={() => edit(offer)}
+              >
+                Edit
+              </button>
               <button
                 className="bg-red-500 text-white px-2 py-1"
                 onClick={() => remove(offer.id)}

--- a/frontend/pages/admin/rfqs.js
+++ b/frontend/pages/admin/rfqs.js
@@ -4,6 +4,8 @@ import withAuth from '../../components/withAuth';
 
 function AdminRFQs() {
   const [rfqs, setRfqs] = useState([]);
+  const [symbol, setSymbol] = useState('');
+  const [quantity, setQuantity] = useState('');
 
   const fetchRFQs = async () => {
     try {
@@ -33,6 +35,43 @@ function AdminRFQs() {
     }
   };
 
+  const create = async (e) => {
+    e.preventDefault();
+    try {
+      const formData = new FormData();
+      formData.append('symbol', symbol);
+      formData.append('quantity', quantity);
+      await axios.post(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`,
+        formData,
+        {
+          withCredentials: true,
+          headers: { 'Content-Type': 'multipart/form-data' },
+        },
+      );
+      setSymbol('');
+      setQuantity('');
+      fetchRFQs();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const edit = async (rfq) => {
+    const newQuantity = prompt('New quantity', rfq.quantity);
+    if (newQuantity === null) return;
+    try {
+      await axios.put(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs/${rfq.id}`,
+        { quantity: newQuantity },
+        { withCredentials: true },
+      );
+      fetchRFQs();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   const reject = async (id) => {
     try {
       await axios.post(
@@ -49,6 +88,23 @@ function AdminRFQs() {
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Manage RFQs</h1>
+      <form onSubmit={create} className="mb-4 space-x-2">
+        <input
+          className="border p-1"
+          placeholder="Commodity"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+        />
+        <input
+          className="border p-1"
+          placeholder="Quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-2 py-1" type="submit">
+          Add
+        </button>
+      </form>
       <ul>
         {rfqs.map((rfq) => (
           <li key={rfq.id} className="border p-2 mb-2">
@@ -70,6 +126,12 @@ function AdminRFQs() {
                   </button>
                 </>
               )}
+              <button
+                className="bg-blue-500 text-white px-2 py-1"
+                onClick={() => edit(rfq)}
+              >
+                Edit
+              </button>
             </div>
           </li>
         ))}

--- a/frontend/pages/admin/transactions.js
+++ b/frontend/pages/admin/transactions.js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import withAuth from '../../components/withAuth';
+
+function AdminTransactions() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/admin/transactions`,
+          { withCredentials: true },
+        );
+        setData(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (!data) return <p>Loading...</p>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Transactions</h1>
+      <h2 className="text-xl mb-2">Active</h2>
+      <ul className="mb-4">
+        {data.active.offers.map((o) => (
+          <li key={`ao-${o.id}`} className="border p-2 mb-2">
+            Offer: {o.symbol} - {o.quantity} ({o.orderStatus})
+          </li>
+        ))}
+        {data.active.rfqs.map((r) => (
+          <li key={`ar-${r.id}`} className="border p-2 mb-2">
+            RFQ: {r.symbol} - {r.quantity} ({r.orderStatus})
+          </li>
+        ))}
+      </ul>
+      <h2 className="text-xl mb-2">Past</h2>
+      <ul>
+        {data.past.offers.map((o) => (
+          <li key={`po-${o.id}`} className="border p-2 mb-2">
+            Offer: {o.symbol} - {o.quantity} ({o.orderStatus})
+          </li>
+        ))}
+        {data.past.rfqs.map((r) => (
+          <li key={`pr-${r.id}`} className="border p-2 mb-2">
+            RFQ: {r.symbol} - {r.quantity} ({r.orderStatus})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(AdminTransactions, 'admin');


### PR DESCRIPTION
## Summary
- allow admins to create offers and RFQs without active subscription
- expose transaction overview endpoint and dashboard page
- add admin UI for managing offers and RFQs (create/edit/delete)

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f1a71dde8832582f14108c8602af5