### PR TITLE
feat: add buyer and seller dashboards with commodity charts

### DIFF
--- a/frontend/components/CommodityCharts.js
+++ b/frontend/components/CommodityCharts.js
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { motion } from 'framer-motion';
+import { useAuth } from '../contexts/AuthContext';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+export default function CommodityCharts() {
+  const { user } = useAuth();
+  const [watchlist, setWatchlist] = useState([]);
+  const [forecastData, setForecastData] = useState([]);
+  const [marketInfo, setMarketInfo] = useState(null);
+  const [selectedSymbol, setSelectedSymbol] = useState('gold');
+  const [symbols, setSymbols] = useState([]);
+  const [loadingWatchlist, setLoadingWatchlist] = useState(true);
+  const [loadingForecast, setLoadingForecast] = useState(true);
+
+  const formatSymbol = (sym) =>
+    sym ? sym.charAt(0).toUpperCase() + sym.slice(1) : '';
+
+  useEffect(() => {
+    const fetchInitialData = async () => {
+      setLoadingWatchlist(true);
+      try {
+        const [watchlistRes, symbolsRes] = await Promise.all([
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/watchlist`, {
+            withCredentials: true,
+          }),
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/market-data`, {
+            withCredentials: true,
+          }),
+        ]);
+        setWatchlist(watchlistRes.data);
+        setSymbols(symbolsRes.data || []);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoadingWatchlist(false);
+      }
+    };
+    if (user) {
+      fetchInitialData();
+    }
+  }, [user]);
+
+  useEffect(() => {
+    const fetchForecast = async () => {
+      setLoadingForecast(true);
+      try {
+        const forecastRes = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/forecast/${selectedSymbol}`,
+          { withCredentials: true }
+        );
+        const marketRes = await axios.get(
+          `${process.env.NEXT_PUBLIC_API_URL}/api/v1/marketData/${selectedSymbol}`,
+          { withCredentials: true }
+        );
+        setMarketInfo(marketRes.data);
+        const { historical = [], forecast = [] } = forecastRes.data;
+        const combined = historical.map((h) => ({
+          date: h.date,
+          historical: h.price,
+        }));
+        forecast.forEach((f) => {
+          combined.push({ date: f.date, forecast: f.price });
+        });
+        setForecastData(combined);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoadingForecast(false);
+      }
+    };
+    if (user) {
+      fetchForecast();
+    }
+  }, [user, selectedSymbol]);
+
+  return (
+    <div>
+      <h1 className="text-2xl mb-4">Watchlist Prices</h1>
+      {loadingWatchlist ? (
+        <div className="w-full h-72 md:h-96 bg-gray-200 animate-pulse rounded" />
+      ) : (
+        <motion.div
+          className="w-full h-72 md:h-96"
+          whileHover={{ scale: 1.02 }}
+          transition={{ duration: 0.2 }}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={watchlist}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="symbol" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="price" stroke="#8884d8" />
+            </LineChart>
+          </ResponsiveContainer>
+        </motion.div>
+      )}
+      <div className="mt-8">
+        <div className="mb-4">
+          <label htmlFor="symbol-select" className="mr-2">
+            Commodity:
+          </label>
+          <select
+            id="symbol-select"
+            value={selectedSymbol}
+            onChange={(e) => setSelectedSymbol(e.target.value)}
+            className="border p-1"
+          >
+            {symbols.length > 0 ? (
+              symbols.map((sym) => (
+                <option key={sym} value={sym}>
+                  {sym.toUpperCase()}
+                </option>
+              ))
+            ) : (
+              <option value="gold">Gold</option>
+            )}
+          </select>
+        </div>
+        <h1 className="text-2xl mb-4">
+          {formatSymbol(selectedSymbol)} Price Forecast
+        </h1>
+        {marketInfo && (
+          <p className="mb-2 text-sm">
+            Category: {marketInfo.category} | Last Updated{' '}
+            {new Date(marketInfo.lastUpdated).toLocaleString()}
+          </p>
+        )}
+        {loadingForecast ? (
+          <div className="w-full h-72 md:h-96 bg-gray-200 animate-pulse rounded" />
+        ) : (
+          <motion.div
+            className="w-full h-72 md:h-96"
+            whileHover={{ scale: 1.02 }}
+            transition={{ duration: 0.2 }}
+          >
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={forecastData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis />
+                <Tooltip />
+                <Line
+                  type="monotone"
+                  dataKey="historical"
+                  stroke="#8884d8"
+                  name="Historical"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="forecast"
+                  stroke="#82ca9d"
+                  name="Forecast"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/pages/buyer/dashboard.js
+++ b/frontend/pages/buyer/dashboard.js
@@ -1,36 +1,69 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import Link from 'next/link';
+import { useAuth } from '../../contexts/AuthContext';
 import withAuth from '../../components/withAuth';
+import CommodityCharts from '../../components/CommodityCharts';
 
 function BuyerDashboard() {
+  const { user } = useAuth();
   const [offers, setOffers] = useState([]);
+  const [rfqs, setRfqs] = useState([]);
 
   useEffect(() => {
-    const fetchOffers = async () => {
+    const fetchData = async () => {
       try {
-        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`, {
-          withCredentials: true,
-        });
-        setOffers(res.data);
+        const [offersRes, rfqsRes] = await Promise.all([
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`, {
+            withCredentials: true,
+          }),
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`, {
+            withCredentials: true,
+          }),
+        ]);
+        setOffers(offersRes.data);
+        if (user) {
+          setRfqs(rfqsRes.data.filter((r) => r.userId === user.id));
+        }
       } catch (err) {
         console.error(err);
       }
     };
-    fetchOffers();
-  }, []);
+    if (user) {
+      fetchData();
+    }
+  }, [user]);
+
+  const responses = offers.filter((o) =>
+    rfqs.some((r) => r.symbol === o.symbol)
+  );
 
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Buyer Dashboard</h1>
-      <Link href="/rfqs/new" className="bg-green-500 text-white px-4 py-2 mb-4 inline-block">
-        Create RFQ
+      <Link
+        href="/rfqs/new"
+        className="bg-green-500 text-white px-4 py-2 mb-4 inline-block"
+      >
+        Post New RFQ
       </Link>
-      <h2 className="text-xl mt-4 mb-2">Available Offers</h2>
+      <CommodityCharts />
+      <h2 className="text-xl mt-8 mb-2">Latest Offers</h2>
       <ul>
         {offers.map((offer) => (
           <li key={offer.id} className="border p-2 mb-2">
             {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status}
+          </li>
+        ))}
+      </ul>
+      <h2 className="text-xl mt-8 mb-2">Responses to My RFQs</h2>
+      <ul>
+        {responses.length === 0 && (
+          <li className="text-sm text-gray-500">No responses yet.</li>
+        )}
+        {responses.map((offer) => (
+          <li key={offer.id} className="border p-2 mb-2">
+            {offer.symbol} - {offer.price} - {offer.quantity}
           </li>
         ))}
       </ul>

--- a/frontend/pages/seller/dashboard.js
+++ b/frontend/pages/seller/dashboard.js
@@ -1,36 +1,70 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import Link from 'next/link';
+import { useAuth } from '../../contexts/AuthContext';
 import withAuth from '../../components/withAuth';
+import CommodityCharts from '../../components/CommodityCharts';
 
 function SellerDashboard() {
+  const { user } = useAuth();
+  const [offers, setOffers] = useState([]);
   const [rfqs, setRfqs] = useState([]);
 
   useEffect(() => {
-    const fetchRfqs = async () => {
+    const fetchData = async () => {
       try {
-        const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`, {
-          withCredentials: true,
-        });
-        setRfqs(res.data);
+        const [offersRes, rfqsRes] = await Promise.all([
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`, {
+            withCredentials: true,
+          }),
+          axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`, {
+            withCredentials: true,
+          }),
+        ]);
+        if (user) {
+          setOffers(offersRes.data.filter((o) => o.userId === user.id));
+        }
+        setRfqs(rfqsRes.data);
       } catch (err) {
         console.error(err);
       }
     };
-    fetchRfqs();
-  }, []);
+    if (user) {
+      fetchData();
+    }
+  }, [user]);
 
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Seller Dashboard</h1>
-      <Link href="/offers/new" className="bg-green-500 text-white px-4 py-2 mb-4 inline-block">
-        Create Offer
+      <CommodityCharts />
+      <Link
+        href="/offers/new"
+        className="bg-green-500 text-white px-4 py-2 mb-4 inline-block"
+      >
+        Add Product Listing
       </Link>
-      <h2 className="text-xl mt-4 mb-2">Recent RFQs</h2>
+      <h2 className="text-xl mt-8 mb-2">My Product Listings</h2>
+      <ul>
+        {offers.map((offer) => (
+          <li key={offer.id} className="border p-2 mb-2">
+            {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status}
+          </li>
+        ))}
+      </ul>
+      <h2 className="text-xl mt-8 mb-2">Buyer RFQs</h2>
       <ul>
         {rfqs.map((rfq) => (
           <li key={rfq.id} className="border p-2 mb-2">
-            {rfq.symbol} - {rfq.quantity} - {rfq.status}
+            <span>
+              {rfq.symbol} - {rfq.quantity} - {rfq.status}
+            </span>
+            <Link
+              href={`/offers/new?rfqId=${rfq.id}`}
+              className="ml-2 text-blue-600 underline"
+            >
+              Respond
+            </Link>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add buyer dashboard with watchlist, RFQ posting and responses
- build seller dashboard for managing listings and responding to RFQs
- introduce shared CommodityCharts component for live prices and AI forecasts

## Testing
- `cd frontend && npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f1cdf801c8325affba14dbd666b6e