### PR TITLE
feat: add marketplace listings fields and contact actions

### DIFF
--- a/backend/migrations/20240901000015-add-marketplace-fields.js
+++ b/backend/migrations/20240901000015-add-marketplace-fields.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Offers', 'priceTier', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Offers', 'location', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('Offers', 'deliveryTerms', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('RFQs', 'specs', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('RFQs', 'location', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Offers', 'priceTier');
+    await queryInterface.removeColumn('Offers', 'location');
+    await queryInterface.removeColumn('Offers', 'deliveryTerms');
+    await queryInterface.removeColumn('RFQs', 'specs');
+    await queryInterface.removeColumn('RFQs', 'location');
+  },
+};

--- a/backend/models/Offer.js
+++ b/backend/models/Offer.js
@@ -7,6 +7,9 @@ module.exports = (sequelize) => {
     symbol: { type: DataTypes.STRING, allowNull: false },
     price: { type: DataTypes.FLOAT, allowNull: false },
     quantity: { type: DataTypes.INTEGER, allowNull: false },
+    priceTier: { type: DataTypes.STRING, allowNull: true },
+    location: { type: DataTypes.STRING, allowNull: true },
+    deliveryTerms: { type: DataTypes.STRING, allowNull: true },
     status: {
       type: DataTypes.ENUM('pending', 'approved', 'featured', 'rejected'),
       allowNull: false,

--- a/backend/models/RFQ.js
+++ b/backend/models/RFQ.js
@@ -6,6 +6,8 @@ module.exports = (sequelize) => {
     userId: { type: DataTypes.INTEGER, allowNull: false },
     symbol: { type: DataTypes.STRING, allowNull: false },
     quantity: { type: DataTypes.INTEGER, allowNull: false },
+    specs: { type: DataTypes.TEXT, allowNull: true },
+    location: { type: DataTypes.STRING, allowNull: true },
     status: {
       type: DataTypes.ENUM('pending', 'approved', 'featured', 'rejected'),
       allowNull: false,

--- a/backend/routes/offers.js
+++ b/backend/routes/offers.js
@@ -35,7 +35,7 @@ router.post(
   upload.array('attachments'),
   async (req, res) => {
     try {
-      const { symbol, price, quantity } = req.body;
+      const { symbol, price, quantity, priceTier, location, deliveryTerms } = req.body;
       const attachments = (req.files || []).map((file) => ({
         filename: file.filename,
         url: `/uploads/${file.filename}`,
@@ -47,6 +47,9 @@ router.post(
         symbol,
         price,
         quantity,
+        priceTier,
+        location,
+        deliveryTerms,
         attachments,
       });
       res.json(offer);

--- a/backend/routes/rfqs.js
+++ b/backend/routes/rfqs.js
@@ -35,7 +35,7 @@ router.post(
   upload.array('attachments'),
   async (req, res) => {
     try {
-      const { symbol, quantity } = req.body;
+      const { symbol, quantity, specs, location } = req.body;
       const attachments = (req.files || []).map((file) => ({
         filename: file.filename,
         url: `/uploads/${file.filename}`,
@@ -46,6 +46,8 @@ router.post(
         userId: req.user.id,
         symbol,
         quantity,
+        specs,
+        location,
         attachments,
       });
       res.json(rfq);

--- a/frontend/pages/offers/[id].js
+++ b/frontend/pages/offers/[id].js
@@ -77,6 +77,9 @@ function OfferDetail() {
       <p>Symbol: {offer.symbol}</p>
       <p>Price: {offer.price}</p>
       <p>Quantity: {offer.quantity}</p>
+      <p>Price Tier: {offer.priceTier}</p>
+      <p>Location: {offer.location}</p>
+      <p>Delivery Terms: {offer.deliveryTerms}</p>
       <p>Status: {offer.status}</p>
       <p>Order Status: {offer.orderStatus}</p>
       <div className="mt-4">

--- a/frontend/pages/offers/index.js
+++ b/frontend/pages/offers/index.js
@@ -144,13 +144,16 @@ function Offers() {
       <ul>
         {offers.map((offer) => (
           <li key={offer.id} className="border p-2 mb-2">
-            {offer.symbol} - {offer.price} - {offer.quantity} - {offer.status} -
-            {offer.orderStatus}
+            <div>
+              Commodity: {offer.symbol} | Price: {offer.price} | Quantity: {offer.quantity}
+            </div>
+            <div>
+              Price Tier: {offer.priceTier || '-'} | Location: {offer.location || '-'}
+            </div>
+            <div>Delivery Terms: {offer.deliveryTerms || '-'}</div>
+            <div>Status: {offer.status} | Order Status: {offer.orderStatus}</div>
             <div className="mt-2 space-x-2">
-              <Link
-                href={`/offers/${offer.id}`}
-                className="text-blue-600 underline"
-              >
+              <Link href={`/offers/${offer.id}`} className="text-blue-600 underline">
                 View
               </Link>
               <Link

--- a/frontend/pages/offers/new.js
+++ b/frontend/pages/offers/new.js
@@ -8,6 +8,9 @@ function NewOffer() {
   const [symbol, setSymbol] = useState('');
   const [price, setPrice] = useState('');
   const [quantity, setQuantity] = useState('');
+  const [priceTier, setPriceTier] = useState('');
+  const [location, setLocation] = useState('');
+  const [deliveryTerms, setDeliveryTerms] = useState('');
   const [files, setFiles] = useState([]);
 
   const handleFileChange = (e) => {
@@ -21,6 +24,9 @@ function NewOffer() {
       formData.append('symbol', symbol);
       formData.append('price', price);
       formData.append('quantity', quantity);
+      formData.append('priceTier', priceTier);
+      formData.append('location', location);
+      formData.append('deliveryTerms', deliveryTerms);
       files.forEach((file) => formData.append('attachments', file));
       await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/offers`, formData, {
         withCredentials: true,
@@ -53,6 +59,24 @@ function NewOffer() {
           placeholder="Quantity"
           value={quantity}
           onChange={(e) => setQuantity(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Price Tier"
+          value={priceTier}
+          onChange={(e) => setPriceTier(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Delivery Terms"
+          value={deliveryTerms}
+          onChange={(e) => setDeliveryTerms(e.target.value)}
         />
         <input type="file" multiple onChange={handleFileChange} />
         <button className="bg-blue-500 text-white px-4 py-2" type="submit">

--- a/frontend/pages/rfqs/[id].js
+++ b/frontend/pages/rfqs/[id].js
@@ -76,6 +76,8 @@ function RFQDetail() {
       <h1 className="text-2xl mb-4">RFQ Details</h1>
       <p>Symbol: {rfq.symbol}</p>
       <p>Quantity: {rfq.quantity}</p>
+      <p>Specifications: {rfq.specs}</p>
+      <p>Delivery Location: {rfq.location}</p>
       <p>Status: {rfq.status}</p>
       <p>Order Status: {rfq.orderStatus}</p>
       <div className="mt-4">

--- a/frontend/pages/rfqs/index.js
+++ b/frontend/pages/rfqs/index.js
@@ -123,19 +123,19 @@ function RFQs() {
       <ul>
         {rfqs.map((rfq) => (
           <li key={rfq.id} className="border p-2 mb-2">
-            {rfq.symbol} - {rfq.quantity} - {rfq.status} - {rfq.orderStatus}
+            <div>
+              Commodity: {rfq.symbol} | Quantity: {rfq.quantity} | Location: {rfq.location || '-'}
+            </div>
+            <div>Status: {rfq.status} | Order Status: {rfq.orderStatus}</div>
             <div className="mt-2 space-x-2">
-              <Link
-                href={`/rfqs/${rfq.id}`}
-                className="text-blue-600 underline"
-              >
+              <Link href={`/rfqs/${rfq.id}`} className="text-blue-600 underline">
                 View
               </Link>
               <Link
                 href={`/messages?toUserId=${rfq.userId}&rfqId=${rfq.id}`}
                 className="text-green-600 underline"
               >
-                Contact Buyer
+                Send Offer
               </Link>
             </div>
           </li>

--- a/frontend/pages/rfqs/new.js
+++ b/frontend/pages/rfqs/new.js
@@ -7,6 +7,8 @@ function NewRFQ() {
   const router = useRouter();
   const [symbol, setSymbol] = useState('');
   const [quantity, setQuantity] = useState('');
+  const [specs, setSpecs] = useState('');
+  const [location, setLocation] = useState('');
   const [files, setFiles] = useState([]);
 
   const handleFileChange = (e) => {
@@ -19,6 +21,8 @@ function NewRFQ() {
       const formData = new FormData();
       formData.append('symbol', symbol);
       formData.append('quantity', quantity);
+      formData.append('specs', specs);
+      formData.append('location', location);
       files.forEach((file) => formData.append('attachments', file));
       await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/rfqs`, formData, {
         withCredentials: true,
@@ -45,6 +49,18 @@ function NewRFQ() {
           placeholder="Quantity"
           value={quantity}
           onChange={(e) => setQuantity(e.target.value)}
+        />
+        <textarea
+          className="border p-2 w-full"
+          placeholder="Specifications"
+          value={specs}
+          onChange={(e) => setSpecs(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Delivery Location"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
         />
         <input type="file" multiple onChange={handleFileChange} />
         <button className="bg-blue-500 text-white px-4 py-2" type="submit">


### PR DESCRIPTION
## Summary
- extend Offer and RFQ models with price tier, location, delivery terms and specs
- allow sellers and buyers to specify these fields when posting
- show new marketplace info in listings with buttons to contact or send offers

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689f202b19b083258d8c05a5a8ef6166