### PR TITLE
Integrate TradingEconomics live price feed

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -23,3 +23,4 @@ This loads initial market data from `data/marketData.json` so scheduled refreshe
 The backend expects configuration via environment variables. Copy `.env.example` to `.env` and provide values. In particular:
 
 - `FRONTEND_URL` — base URL of the frontend application used in verification and password reset emails and for CORS.
+- `TRADING_ECONOMICS_KEY` — credentials for the TradingEconomics API in the form `username:password` (defaults to `guest:guest`).

--- a/backend/services/tradingEconomicsService.js
+++ b/backend/services/tradingEconomicsService.js
@@ -1,0 +1,27 @@
+const fetch = global.fetch;
+
+async function fetchCommodity(symbol) {
+  const credentials = process.env.TRADING_ECONOMICS_KEY || 'guest:guest';
+  const url = `https://api.tradingeconomics.com/commodity/${encodeURIComponent(symbol)}?c=${credentials}&format=json`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`TradingEconomics request failed with status ${response.status}`);
+  }
+  const data = await response.json();
+  const item = Array.isArray(data) ? data[0] : data;
+  const price =
+    item?.price ??
+    item?.last ??
+    item?.close ??
+    item?.Close ??
+    item?.Price ?? null;
+  const changePercent =
+    item?.changePercent ??
+    item?.ChangePercent ??
+    item?.PercentageChange ??
+    item?.Change_p ??
+    item?.change ?? null;
+  return { price, changePercent };
+}
+
+module.exports = { fetchCommodity };


### PR DESCRIPTION
## Summary
- fetch live commodity prices via TradingEconomics service
- expose price direction and color-coded arrow in market data response
- document TradingEconomics API key requirement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f248a837083259740e82a3bd216e3