### PR TITLE
Add Stripe subscription support with cancel option

### DIFF
--- a/backend/routes/payments.js
+++ b/backend/routes/payments.js
@@ -1,14 +1,14 @@
 const express = require('express');
 const auth = require('../middleware/auth');
 const Stripe = require('stripe');
+const { User } = require('../models');
 
 const router = express.Router();
 const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
 
 // Map subscription plans to Stripe price IDs
 const priceMap = {
-  basic: process.env.STRIPE_BASIC_PRICE_ID,
-  pro: process.env.STRIPE_PRO_PRICE_ID,
+  premium: process.env.STRIPE_PREMIUM_PRICE_ID,
 };
 
 router.get('/create-checkout-session', auth, async (req, res) => {
@@ -30,6 +30,7 @@ router.get('/create-checkout-session', auth, async (req, res) => {
       ],
       success_url: `${process.env.FRONTEND_URL}/success`,
       cancel_url: `${process.env.FRONTEND_URL}/cancel`,
+      customer_email: req.user.username,
       subscription_data: {
         metadata: { userId: req.user.id, plan },
       },
@@ -37,6 +38,45 @@ router.get('/create-checkout-session', auth, async (req, res) => {
 
     // Redirect user to Stripe hosted checkout page
     res.redirect(303, session.url);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Allow users to cancel their active subscription
+router.post('/cancel-subscription', auth, async (req, res) => {
+  try {
+    const customerList = await stripe.customers.list({
+      email: req.user.username,
+      limit: 1,
+    });
+    const customer = customerList.data[0];
+    if (!customer) {
+      return res.status(404).json({ error: 'Customer not found' });
+    }
+
+    const subscriptions = await stripe.subscriptions.list({
+      customer: customer.id,
+      status: 'active',
+      limit: 1,
+    });
+    const subscription = subscriptions.data[0];
+    if (!subscription) {
+      return res.status(400).json({ error: 'No active subscription' });
+    }
+
+    await stripe.subscriptions.del(subscription.id);
+
+    const user = await User.findByPk(req.user.id);
+    if (user) {
+      user.subscriptionStatus = 'canceled';
+      if (user.role === 'subscriber') {
+        user.role = 'buyer';
+      }
+      await user.save();
+    }
+
+    res.json({ message: 'Subscription canceled' });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/backend/webhooks/stripe.js
+++ b/backend/webhooks/stripe.js
@@ -26,10 +26,16 @@ module.exports = async (req, res) => {
       switch (event.type) {
         case 'customer.subscription.deleted':
           user.subscriptionStatus = 'canceled';
+          if (user.role === 'subscriber') {
+            user.role = 'buyer';
+          }
           break;
         case 'customer.subscription.created':
         case 'customer.subscription.updated':
           user.subscriptionStatus = subscription.status;
+          if (subscription.status === 'active') {
+            user.role = 'subscriber';
+          }
           break;
         default:
           break;

--- a/frontend/pages/cancel.js
+++ b/frontend/pages/cancel.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Cancel() {
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-2xl font-bold mb-4">Payment Canceled</h1>
+      <p>Your subscription was not completed.</p>
+    </div>
+  );
+}

--- a/frontend/pages/pricing.js
+++ b/frontend/pages/pricing.js
@@ -2,21 +2,25 @@ import React from 'react';
 
 const plans = [
   {
-    name: 'Basic',
-    price: '$10 / month',
-    features: ['Core trading tools', 'Community support'],
-    planId: 'basic',
+    name: 'Free',
+    price: '$0',
+    features: ['Limited access to features'],
+    planId: 'free',
   },
   {
-    name: 'Pro',
+    name: 'Premium',
     price: '$30 / month',
-    features: ['Everything in Basic', 'Priority support', 'Advanced analytics'],
-    planId: 'pro',
+    features: ['Full access to all features'],
+    planId: 'premium',
   },
 ];
 
 export default function Pricing() {
   const handleSubscribe = (plan) => {
+    if (plan === 'free') {
+      window.location.href = '/signup';
+      return;
+    }
     window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/payments/create-checkout-session?plan=${plan}`;
   };
 
@@ -37,7 +41,7 @@ export default function Pricing() {
               onClick={() => handleSubscribe(p.planId)}
               className="mt-auto px-4 py-2 bg-brand text-white rounded-md hover:bg-brand-dark"
             >
-              Subscribe
+              {p.planId === 'free' ? 'Get Started' : 'Subscribe'}
             </button>
           </div>
         ))}

--- a/frontend/pages/profile.js
+++ b/frontend/pages/profile.js
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import withAuth from '../components/withAuth';
 
 function Profile() {
-  const { user } = useAuth();
+  const { user, login } = useAuth();
   const [companyName, setCompanyName] = useState('');
   const [companyWebsite, setCompanyWebsite] = useState('');
   const [logo, setLogo] = useState(null);
@@ -50,6 +50,19 @@ function Profile() {
     }
   };
 
+  const handleCancelSubscription = async () => {
+    try {
+      await axios.post(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/payments/cancel-subscription`,
+        {},
+        { withCredentials: true }
+      );
+      login({ ...user, role: 'buyer', subscriptionStatus: 'canceled' });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-2xl mb-4">Profile</h1>
@@ -78,6 +91,14 @@ function Profile() {
           Save
         </button>
       </form>
+      {user?.role === 'subscriber' && (
+        <button
+          onClick={handleCancelSubscription}
+          className="mt-4 bg-red-500 text-white px-4 py-2"
+        >
+          Cancel Subscription
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/pages/success.js
+++ b/frontend/pages/success.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Success() {
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-2xl font-bold mb-4">Payment Successful</h1>
+      <p>Your subscription is now active.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Implement premium subscription checkout and cancellation endpoints using Stripe
- Update webhook to grant subscriber role and revoke on cancellation
- Add pricing page with Free and Premium plans and profile option to cancel subscriptions

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689f27fd36e083259336a3145a1e3979