### PR TITLE
Add role and status fields for default admin user

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -67,6 +67,9 @@ sequelize.sync().then(async () => {
       username: 'admin',
       email: 'admin@example.com',
       password: 'dummyhash', // You can later replace with bcrypt hash
+      role: 'admin',
+      status: 'active',
+      subscriptionStatus: 'inactive',
     },
   });
 


### PR DESCRIPTION
## Summary
- Ensure default admin user includes role, status, and subscriptionStatus when auto-created

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a71ed598448325b1b3edf498cf6782