### PR TITLE
Add RFQ list and negotiation pages

### DIFF
--- a/frontend/pages/app/rfqs/[id].tsx
+++ b/frontend/pages/app/rfqs/[id].tsx
@@ -1,0 +1,208 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { apiFetch } from '../../../lib/api';
+
+interface Attachment {
+  id: number;
+  name?: string;
+  url: string;
+}
+
+interface ThreadItem {
+  id: number;
+  type: 'message' | 'offer';
+  senderName?: string;
+  content?: string;
+  price?: number;
+  terms?: string;
+  status?: string;
+  createdAt: string;
+}
+
+interface RFQ {
+  id: number;
+  commodity: string;
+  region: string;
+  incoterms: string;
+  quantity: number;
+  status: string;
+  expiry?: string;
+  attachments?: Attachment[];
+  thread?: ThreadItem[];
+}
+
+const statusColor = (s?: string) => {
+  switch ((s || '').toLowerCase()) {
+    case 'accepted':
+      return 'bg-green-200 text-green-800';
+    case 'counter':
+      return 'bg-yellow-200 text-yellow-800';
+    case 'rejected':
+      return 'bg-red-200 text-red-800';
+    default:
+      return 'bg-gray-200 text-gray-800';
+  }
+};
+
+export default function RfqDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [rfq, setRfq] = useState<RFQ | null>(null);
+  const [timeLeft, setTimeLeft] = useState('');
+  const [price, setPrice] = useState('');
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const loadRfq = async () => {
+    if (!id) return;
+    try {
+      const data = await apiFetch(`/api/v1/rfqs/${id}`);
+      setRfq(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    loadRfq();
+  }, [id]);
+
+  useEffect(() => {
+    if (!rfq?.expiry) return;
+    const update = () => {
+      const diff = new Date(rfq.expiry!).getTime() - Date.now();
+      if (diff <= 0) {
+        setTimeLeft('Expired');
+        return;
+      }
+      const h = Math.floor(diff / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      setTimeLeft(`${h}h ${m}m ${s}s`);
+    };
+    update();
+    const t = setInterval(update, 1000);
+    return () => clearInterval(t);
+  }, [rfq?.expiry]);
+
+  const expired = timeLeft === 'Expired';
+
+  const submitOffer = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!price) return;
+    setLoading(true);
+    try {
+      await apiFetch(`/api/v1/rfqs/${id}/offers`, {
+        method: 'POST',
+        body: JSON.stringify({ price: Number(price), message }),
+      });
+      setPrice('');
+      setMessage('');
+      await loadRfq();
+    } catch (err: any) {
+      if (typeof window !== 'undefined') alert(err.message || 'Failed to send offer');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!rfq) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 flex flex-col md:flex-row gap-4">
+      <div className="md:w-1/3 space-y-4">
+        <div className="border rounded p-4">
+          <h2 className="text-lg font-semibold mb-2">RFQ #{rfq.id}</h2>
+          <div>Commodity: {rfq.commodity}</div>
+          <div>Region: {rfq.region}</div>
+          <div>Incoterms: {rfq.incoterms}</div>
+          <div>Quantity: {rfq.quantity}</div>
+          <div>Status: {rfq.status}</div>
+          {rfq.expiry && <div>Expires in: {timeLeft}</div>}
+        </div>
+        {rfq.attachments && rfq.attachments.length > 0 && (
+          <div className="border rounded p-4">
+            <h3 className="font-semibold mb-2">Attachments</h3>
+            <ul className="list-disc list-inside space-y-1">
+              {rfq.attachments.map((a) => (
+                <li key={a.id}>
+                  <a
+                    href={a.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 underline"
+                  >
+                    {a.name || a.url}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      <div className="flex-1 flex flex-col">
+        <div className="flex-1 overflow-y-auto border rounded p-4 space-y-4">
+          {rfq.thread && rfq.thread.length > 0 ? (
+            rfq.thread.map((item) => (
+              <div key={item.id} className="flex items-start gap-2">
+                <div className="w-8 h-8 rounded-full bg-neutral-700 flex items-center justify-center text-sm">
+                  {item.senderName ? item.senderName.charAt(0).toUpperCase() : '?'}
+                </div>
+                <div className="flex-1">
+                  <div className="text-xs text-neutral-400">
+                    {item.senderName} • {new Date(item.createdAt).toLocaleString()}
+                  </div>
+                  {item.type === 'offer' ? (
+                    <div className="mt-1 border rounded p-2">
+                      <div>Price: {item.price}</div>
+                      {item.terms && <div>Terms: {item.terms}</div>}
+                      {item.status && (
+                        <div className="mt-1">
+                          <span className={`px-2 py-1 rounded text-xs ${statusColor(item.status)}`}>
+                            {item.status}
+                          </span>
+                        </div>
+                      )}
+                      {item.content && <div className="mt-1">{item.content}</div>}
+                    </div>
+                  ) : (
+                    <div className="mt-1">{item.content}</div>
+                  )}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div>No messages yet</div>
+          )}
+        </div>
+        <form onSubmit={submitOffer} className="mt-4 flex gap-2">
+          <input
+            type="number"
+            placeholder="Offer price"
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+            className="border p-2 rounded flex-1"
+            disabled={expired || loading}
+          />
+          <input
+            type="text"
+            placeholder="Message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            className="border p-2 rounded flex-1"
+            disabled={expired || loading}
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            disabled={expired || loading}
+          >
+            Send
+          </button>
+        </form>
+        {expired && <div className="mt-2 text-red-600">RFQ expired - new offers disabled.</div>}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/pages/app/rfqs/index.tsx
+++ b/frontend/pages/app/rfqs/index.tsx
@@ -1,0 +1,299 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { apiFetch } from '../../../lib/api';
+
+interface RFQ {
+  id: number;
+  commodity: string;
+  region: string;
+  incoterms: string;
+  quantity: number;
+  status: string;
+  createdAt: string;
+}
+
+const statusColors: Record<string, string> = {
+  open: 'bg-green-200 text-green-800',
+  accepted: 'bg-blue-200 text-blue-800',
+  closed: 'bg-gray-200 text-gray-800',
+  expired: 'bg-red-200 text-red-800',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span className={`px-2 py-1 rounded text-xs capitalize ${
+      statusColors[status.toLowerCase()] || 'bg-gray-200 text-gray-800'
+    }`}>{status}</span>
+  );
+}
+
+interface CreateModalProps {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+function CreateRfqModal({ onClose, onCreated }: CreateModalProps) {
+  const [product, setProduct] = useState('');
+  const [region, setRegion] = useState('');
+  const [incoterms, setIncoterms] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [targetPrice, setTargetPrice] = useState('');
+  const [expiry, setExpiry] = useState('');
+  const [notes, setNotes] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (!product || !region || !incoterms || !quantity || !expiry) {
+      setError('Please fill all required fields');
+      return;
+    }
+    if (isNaN(Number(quantity))) {
+      setError('Quantity must be numeric');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await apiFetch('/api/v1/rfqs', {
+        method: 'POST',
+        body: JSON.stringify({
+          product,
+          region,
+          incoterms,
+          quantity: Number(quantity),
+          targetPrice: targetPrice ? Number(targetPrice) : undefined,
+          expiry,
+          notes,
+        }),
+      });
+      onCreated();
+      onClose();
+      if (typeof window !== 'undefined') alert('RFQ created');
+    } catch (err: any) {
+      setError(err.message || 'Failed to create RFQ');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white text-black p-6 rounded w-full max-w-lg overflow-y-auto max-h-[90vh]">
+        <h2 className="text-xl font-semibold mb-4">Create RFQ</h2>
+        {error && <div className="text-red-600 mb-2">{error}</div>}
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block mb-1">Product/Grade*</label>
+            <input
+              type="text"
+              value={product}
+              onChange={(e) => setProduct(e.target.value)}
+              className="w-full border p-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Region*</label>
+            <input
+              type="text"
+              value={region}
+              onChange={(e) => setRegion(e.target.value)}
+              className="w-full border p-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Incoterms*</label>
+            <input
+              type="text"
+              value={incoterms}
+              onChange={(e) => setIncoterms(e.target.value)}
+              className="w-full border p-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Quantity*</label>
+            <input
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              className="w-full border p-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Target Price</label>
+            <input
+              type="number"
+              value={targetPrice}
+              onChange={(e) => setTargetPrice(e.target.value)}
+              className="w-full border p-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Expiry Date/Time*</label>
+            <input
+              type="datetime-local"
+              value={expiry}
+              onChange={(e) => setExpiry(e.target.value)}
+              className="w-full border p-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Notes</label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className="w-full border p-2 rounded"
+            />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 bg-gray-200 rounded"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            >
+              {submitting ? 'Saving...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function RFQsPage() {
+  const [rfqs, setRfqs] = useState<RFQ[]>([]);
+  const [status, setStatus] = useState('');
+  const [commodity, setCommodity] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [showModal, setShowModal] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const loadRfqs = async () => {
+    setLoading(true);
+    try {
+      const data = await apiFetch('/api/v1/rfqs');
+      setRfqs(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadRfqs();
+  }, []);
+
+  const filtered = useMemo(() => {
+    return rfqs.filter((r) => {
+      const created = new Date(r.createdAt);
+      return (
+        (!status || r.status === status) &&
+        (!commodity || (r.commodity || '').toLowerCase().includes(commodity.toLowerCase())) &&
+        (!from || created >= new Date(from)) &&
+        (!to || created <= new Date(to))
+      );
+    });
+  }, [rfqs, status, commodity, from, to]);
+
+  return (
+    <div className="p-4">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-2xl font-semibold">RFQs</h1>
+        <button
+          onClick={() => setShowModal(true)}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Create RFQ
+        </button>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="">All Statuses</option>
+          <option value="open">Open</option>
+          <option value="accepted">Accepted</option>
+          <option value="closed">Closed</option>
+          <option value="expired">Expired</option>
+        </select>
+        <input
+          type="text"
+          placeholder="Commodity"
+          value={commodity}
+          onChange={(e) => setCommodity(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="date"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="date"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          className="border p-2 rounded"
+        />
+      </div>
+      <div className="overflow-auto">
+        <table className="min-w-full text-left border">
+          <thead className="bg-neutral-800 text-neutral-100">
+            <tr>
+              <th className="p-2">RFQ ID</th>
+              <th className="p-2">Commodity</th>
+              <th className="p-2">Region</th>
+              <th className="p-2">Incoterms</th>
+              <th className="p-2">Quantity</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Created At</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr><td colSpan={7} className="p-4 text-center">Loading...</td></tr>
+            ) : filtered.length === 0 ? (
+              <tr><td colSpan={7} className="p-4 text-center">No RFQs found</td></tr>
+            ) : (
+              filtered.map((r) => (
+                <tr
+                  key={r.id}
+                  onClick={() => router.push(`/app/rfqs/${r.id}`)}
+                  className="cursor-pointer hover:bg-neutral-800"
+                >
+                  <td className="p-2">{r.id}</td>
+                  <td className="p-2">{r.commodity}</td>
+                  <td className="p-2">{r.region}</td>
+                  <td className="p-2">{r.incoterms}</td>
+                  <td className="p-2">{r.quantity}</td>
+                  <td className="p-2"><StatusBadge status={r.status} /></td>
+                  <td className="p-2">{new Date(r.createdAt).toLocaleDateString()}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {showModal && (
+        <CreateRfqModal
+          onClose={() => setShowModal(false)}
+          onCreated={loadRfqs}
+        />
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Build `/app/rfqs` page with RFQ table, filters and creation modal
- Add `/app/rfqs/[id]` detail view with summary card, thread and offer submission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfe1c267148325b900e06b4618ee22