### PR TITLE
feat: polish UI with theme, components and toasts

### DIFF
--- a/frontend/components/AppShell.tsx
+++ b/frontend/components/AppShell.tsx
@@ -3,6 +3,9 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useAuth } from '../contexts/AuthContext';
 import { apiFetch } from '../lib/api';
+import Button from './ui/Button';
+import Skeleton from './ui/Skeleton';
+import { Bars3Icon } from '@heroicons/react/24/outline';
 
 interface TickerItem {
   symbol: string;
@@ -19,6 +22,7 @@ export default function AppShell({ children }: AppShellProps) {
   const { user, logout } = useAuth();
   const [ticker, setTicker] = useState<TickerItem[]>([]);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     const fetchTicker = async () => {
@@ -53,12 +57,22 @@ export default function AppShell({ children }: AppShellProps) {
 
   return (
     <div className="flex min-h-screen bg-neutral-950 text-neutral-100">
-      <nav className="w-[260px] flex-shrink-0 bg-neutral-900 p-4 flex flex-col space-y-2">
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+      <nav
+        aria-label="Primary"
+        className={`fixed inset-y-0 left-0 z-40 w-64 transform bg-neutral-900 p-4 space-y-2 transition-transform md:relative md:translate-x-0 md:flex md:flex-col ${sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}
+      >
         {navItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
-            className={`px-3 py-2 rounded ${linkClass(item.href)}`}
+            className={`px-3 py-2 rounded-2xl ${linkClass(item.href)}`}
+            onClick={() => setSidebarOpen(false)}
           >
             {item.label}
           </Link>
@@ -66,25 +80,34 @@ export default function AppShell({ children }: AppShellProps) {
       </nav>
       <div className="flex-1 flex flex-col">
         <header className="flex items-center justify-between p-4 border-b border-neutral-800">
-          <div className="text-xl font-bold">FalconTrade</div>
+          <div className="flex items-center space-x-2">
+            <Button
+              className="md:hidden p-2 bg-neutral-800"
+              onClick={() => setSidebarOpen(true)}
+              aria-label="Open navigation"
+            >
+              <Bars3Icon className="w-5 h-5" />
+            </Button>
+            <div className="text-xl font-bold">FalconTrade</div>
+          </div>
           <input
             type="text"
             placeholder="Search symbols, RFQs..."
-            className="w-full max-w-md mx-4 px-3 py-2 rounded bg-neutral-800 text-neutral-100 focus:outline-none"
+            className="w-full max-w-md mx-4 px-3 py-2 rounded-2xl bg-neutral-800 text-neutral-100 focus:outline-none focus:ring-2 focus:ring-brand-light"
           />
           {user ? (
             <div className="relative">
               <button
                 onClick={() => setMenuOpen(!menuOpen)}
-                className="w-8 h-8 rounded-full bg-neutral-700 flex items-center justify-center"
+                className="w-8 h-8 rounded-full bg-neutral-700 flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-brand-light"
               >
                 {user.name ? user.name.charAt(0).toUpperCase() : 'U'}
               </button>
               {menuOpen && (
-                <div className="absolute right-0 mt-2 w-40 bg-neutral-900 border border-neutral-700 rounded shadow-lg">
+                <div className="absolute right-0 mt-2 w-40 bg-neutral-900 border border-neutral-700 rounded-2xl shadow-lg">
                   <button
                     onClick={logout}
-                    className="block w-full text-left px-4 py-2 hover:bg-neutral-800"
+                    className="block w-full text-left px-4 py-2 hover:bg-neutral-800 rounded-2xl"
                   >
                     Logout
                   </button>
@@ -103,22 +126,28 @@ export default function AppShell({ children }: AppShellProps) {
           )}
         </header>
         <div className="flex border-b border-neutral-800 overflow-x-auto">
-          {ticker.map((item) => (
-            <div
-              key={item.symbol}
-              className="flex items-center space-x-2 px-4 py-1"
-            >
-              <span>{item.symbol}</span>
-              <span className="font-mono">{item.last}</span>
-              <span
-                className={`font-mono ${
-                  item.changePercent >= 0 ? 'text-green-500' : 'text-red-500'
-                }`}
-              >
-                {item.changePercent}%
-              </span>
-            </div>
-          ))}
+          {ticker.length === 0
+            ? Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="w-32 h-6 m-2" />
+              ))
+            : ticker.map((item) => (
+                <div
+                  key={item.symbol}
+                  className="flex items-center space-x-2 px-4 py-1"
+                >
+                  <span>{item.symbol}</span>
+                  <span className="font-mono">{item.last}</span>
+                  <span
+                    className={`font-mono ${
+                      item.changePercent >= 0
+                        ? 'text-green-500'
+                        : 'text-red-500'
+                    }`}
+                  >
+                    {item.changePercent}%
+                  </span>
+                </div>
+              ))}
         </div>
         <main className="p-4 flex-1 overflow-y-auto">{children}</main>
       </div>

--- a/frontend/components/ThemeToggle.js
+++ b/frontend/components/ThemeToggle.js
@@ -1,23 +1,32 @@
 import { useEffect, useState } from 'react';
+import Button from './ui/Button';
 
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(false);
 
   useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) {
+      setIsDark(stored === 'dark');
+    } else {
+      setIsDark(window.matchMedia('(prefers-color-scheme: dark)').matches);
+    }
+  }, []);
+
+  useEffect(() => {
     if (isDark) {
       document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
     } else {
       document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
     }
     window.dispatchEvent(new Event('themeChange'));
   }, [isDark]);
 
   return (
-    <button
-      onClick={() => setIsDark(!isDark)}
-      className="p-2 rounded bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-200"
-    >
+    <Button onClick={() => setIsDark(!isDark)} className="fixed top-4 right-4 z-50">
       {isDark ? 'Light Mode' : 'Dark Mode'}
-    </button>
+    </Button>
   );
 }

--- a/frontend/components/ui/Button.js
+++ b/frontend/components/ui/Button.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Button({ className = '', ...props }) {
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded-2xl px-4 py-2 bg-brand text-white shadow focus:outline-none focus:ring-2 focus:ring-brand-light disabled:opacity-50 ${className}`}
+      {...props}
+    />
+  );
+}

--- a/frontend/components/ui/Input.js
+++ b/frontend/components/ui/Input.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Input({ className = '', ...props }) {
+  return (
+    <input
+      className={`rounded-2xl border border-neutral-300 bg-white dark:bg-neutral-800 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-light ${className}`}
+      {...props}
+    />
+  );
+}

--- a/frontend/components/ui/Modal.js
+++ b/frontend/components/ui/Modal.js
@@ -1,0 +1,36 @@
+import React, { Fragment } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+
+export default function Modal({ open, onClose, title, children }) {
+  return (
+    <Transition show={open} as={Fragment}>
+      <Dialog onClose={onClose} className="fixed inset-0 z-50 flex items-center justify-center">
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        </Transition.Child>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0 scale-95"
+          enterTo="opacity-100 scale-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100 scale-100"
+          leaveTo="opacity-0 scale-95"
+        >
+          <div className="relative z-50 bg-white dark:bg-neutral-900 rounded-2xl p-6 shadow-xl w-full max-w-lg">
+            {title && <Dialog.Title className="text-lg font-medium mb-4">{title}</Dialog.Title>}
+            {children}
+          </div>
+        </Transition.Child>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/components/ui/Skeleton.js
+++ b/frontend/components/ui/Skeleton.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Skeleton({ className = '' }) {
+  return (
+    <div className={`animate-pulse bg-neutral-200 dark:bg-neutral-700 rounded-2xl ${className}`} />
+  );
+}

--- a/frontend/components/ui/Table.js
+++ b/frontend/components/ui/Table.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Table({ className = '', ...props }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className={`min-w-full rounded-2xl overflow-hidden ${className}`} {...props} />
+    </div>
+  );
+}

--- a/frontend/components/ui/ToastProvider.js
+++ b/frontend/components/ui/ToastProvider.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Toaster } from 'react-hot-toast';
+
+export default function ToastProvider() {
+  return (
+    <Toaster
+      position="top-right"
+      toastOptions={{
+        className: 'rounded-2xl bg-neutral-800 text-neutral-100 shadow',
+        success: { className: 'bg-green-600 text-white' },
+        error: { className: 'bg-red-600 text-white' }
+      }}
+    />
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "falcontrade-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.2.0",
         "axios": "^1.11.0",
         "chart.js": "^4.5.0",
@@ -15,7 +16,8 @@
         "next": "14.2.5",
         "react": "18.2.0",
         "react-chartjs-2": "^5.3.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "react-hot-toast": "^2.4.1"
       },
       "devDependencies": {
         "@types/node": "24.3.1",
@@ -37,6 +39,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.19",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
+      "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/@heroicons/react": {
@@ -316,6 +335,33 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/node": {
@@ -701,7 +747,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -1057,6 +1102,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -1754,6 +1808,23 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,9 @@
     "next": "14.2.5",
     "react": "18.2.0",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@headlessui/react": "^1.7.18",
+    "react-hot-toast": "^2.4.1"
   },
   "devDependencies": {
     "@types/node": "24.3.1",

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -7,6 +7,8 @@ import PublicNav from '../components/PublicNav';
 import Layout from '../components/Layout';
 import AppShell from '../components/AppShell';
 import { useRouter } from 'next/router';
+import ToastProvider from '../components/ui/ToastProvider';
+import { toast } from 'react-hot-toast';
 
 function AppContent({ Component, pageProps }) {
   const { user } = useAuth();
@@ -18,7 +20,7 @@ function AppContent({ Component, pageProps }) {
       (response) => response,
       (error) => {
         if (typeof window !== 'undefined') {
-          alert(
+          toast.error(
             error.response?.data?.error || 'An unexpected error occurred'
           );
         }
@@ -30,9 +32,12 @@ function AppContent({ Component, pageProps }) {
 
   if (isAppRoute) {
     return (
-      <AppShell>
-        <Component {...pageProps} />
-      </AppShell>
+      <>
+        <ThemeToggle />
+        <AppShell>
+          <Component {...pageProps} />
+        </AppShell>
+      </>
     );
   }
 
@@ -49,6 +54,7 @@ function AppContent({ Component, pageProps }) {
 export default function MyApp({ Component, pageProps }) {
   return (
     <AuthProvider>
+      <ToastProvider />
       <AppContent Component={Component} pageProps={pageProps} />
     </AuthProvider>
   );

--- a/frontend/pages/app/admin.tsx
+++ b/frontend/pages/app/admin.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../contexts/AuthContext';
 import { apiFetch } from '../../lib/api';
 import systemConfig from '../../config/systemConfig.json';
+import { toast } from 'react-hot-toast';
 
 interface User {
   id: number;
@@ -70,7 +71,7 @@ export default function AdminDashboard() {
   };
 
   const requestInfo = (id: number) => {
-    alert(`Requesting more info for user ${id}`);
+    toast(`Requesting more info for user ${id}`);
   };
 
   if (loading || !user || user.role !== 'admin') {
@@ -119,7 +120,7 @@ export default function AdminDashboard() {
       <section className="mb-8">
         <h2 className="text-xl font-semibold mb-4">Recent Signups</h2>
         <div className="overflow-x-auto">
-          <table className="min-w-full text-sm">
+          <table className="min-w-full text-sm rounded-2xl overflow-hidden">
             <thead>
               <tr className="bg-neutral-900">
                 <th className="px-3 py-2 text-left">Username</th>

--- a/frontend/pages/app/markets/index.tsx
+++ b/frontend/pages/app/markets/index.tsx
@@ -96,8 +96,8 @@ export default function MarketsPage() {
         />
       </div>
       {error && <div className="text-red-600 mb-4">{error}</div>}
-      <div className="overflow-auto max-h-[70vh]">
-        <table className="min-w-full">
+      <div className="overflow-x-auto max-h-[70vh]">
+        <table className="min-w-full rounded-2xl overflow-hidden">
           <thead className="sticky top-0 bg-white">
             <tr>
               <th className="text-left p-2">Symbol</th>

--- a/frontend/pages/app/rfqs/[id].tsx
+++ b/frontend/pages/app/rfqs/[id].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { apiFetch } from '../../../lib/api';
+import { toast } from 'react-hot-toast';
 
 interface Attachment {
   id: number;
@@ -100,7 +101,7 @@ export default function RfqDetail() {
       setMessage('');
       await loadRfq();
     } catch (err: any) {
-      if (typeof window !== 'undefined') alert(err.message || 'Failed to send offer');
+      toast.error(err.message || 'Failed to send offer');
     } finally {
       setLoading(false);
     }

--- a/frontend/pages/app/rfqs/index.tsx
+++ b/frontend/pages/app/rfqs/index.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { apiFetch } from '../../../lib/api';
+import { toast } from 'react-hot-toast';
+import Modal from '../../../components/ui/Modal';
 
 interface RFQ {
   id: number;
@@ -70,7 +72,7 @@ function CreateRfqModal({ onClose, onCreated }: CreateModalProps) {
       });
       onCreated();
       onClose();
-      if (typeof window !== 'undefined') alert('RFQ created');
+      toast.success('RFQ created');
     } catch (err: any) {
       setError(err.message || 'Failed to create RFQ');
     } finally {
@@ -79,92 +81,89 @@ function CreateRfqModal({ onClose, onCreated }: CreateModalProps) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white text-black p-6 rounded w-full max-w-lg overflow-y-auto max-h-[90vh]">
-        <h2 className="text-xl font-semibold mb-4">Create RFQ</h2>
-        {error && <div className="text-red-600 mb-2">{error}</div>}
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div>
-            <label className="block mb-1">Product/Grade*</label>
-            <input
-              type="text"
-              value={product}
-              onChange={(e) => setProduct(e.target.value)}
-              className="w-full border p-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Region*</label>
-            <input
-              type="text"
-              value={region}
-              onChange={(e) => setRegion(e.target.value)}
-              className="w-full border p-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Incoterms*</label>
-            <input
-              type="text"
-              value={incoterms}
-              onChange={(e) => setIncoterms(e.target.value)}
-              className="w-full border p-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Quantity*</label>
-            <input
-              type="number"
-              value={quantity}
-              onChange={(e) => setQuantity(e.target.value)}
-              className="w-full border p-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Target Price</label>
-            <input
-              type="number"
-              value={targetPrice}
-              onChange={(e) => setTargetPrice(e.target.value)}
-              className="w-full border p-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Expiry Date/Time*</label>
-            <input
-              type="datetime-local"
-              value={expiry}
-              onChange={(e) => setExpiry(e.target.value)}
-              className="w-full border p-2 rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Notes</label>
-            <textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              className="w-full border p-2 rounded"
-            />
-          </div>
-          <div className="flex justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 bg-gray-200 rounded"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={submitting}
-              className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
-            >
-              {submitting ? 'Saving...' : 'Create'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+    <Modal open onClose={onClose} title="Create RFQ">
+      {error && <div className="text-red-600 mb-2">{error}</div>}
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label className="block mb-1">Product/Grade*</label>
+          <input
+            type="text"
+            value={product}
+            onChange={(e) => setProduct(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Region*</label>
+          <input
+            type="text"
+            value={region}
+            onChange={(e) => setRegion(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Incoterms*</label>
+          <input
+            type="text"
+            value={incoterms}
+            onChange={(e) => setIncoterms(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Quantity*</label>
+          <input
+            type="number"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Target Price</label>
+          <input
+            type="number"
+            value={targetPrice}
+            onChange={(e) => setTargetPrice(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Expiry Date/Time*</label>
+          <input
+            type="datetime-local"
+            value={expiry}
+            onChange={(e) => setExpiry(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Notes</label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            className="w-full border p-2 rounded"
+          />
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 bg-gray-200 rounded"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          >
+            {submitting ? 'Saving...' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </Modal>
   );
 }
 
@@ -249,8 +248,8 @@ export default function RFQsPage() {
           className="border p-2 rounded"
         />
       </div>
-      <div className="overflow-auto">
-        <table className="min-w-full text-left border">
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-left border rounded-2xl overflow-hidden">
           <thead className="bg-neutral-800 text-neutral-100">
             <tr>
               <th className="p-2">RFQ ID</th>

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import axios from 'axios';
 import { useAuth } from '../contexts/AuthContext';
+import { toast } from 'react-hot-toast';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
 
 export default function Login() {
   const [username, setUsername] = useState('');
@@ -21,24 +24,24 @@ export default function Login() {
       router.push('/');
     } catch (err) {
       if (err.response && err.response.status === 403) {
-        alert(err.response.data.message);
+        toast.error(err.response.data.message);
       } else {
-        alert('Login failed');
+        toast.error('Login failed');
       }
     }
   };
 
   return (
     <form onSubmit={handleSubmit}>
-      <div>
-        <label>Username:</label>
-        <input value={username} onChange={(e) => setUsername(e.target.value)} />
+      <div className="space-y-2">
+        <label className="block">Username:</label>
+        <Input value={username} onChange={(e) => setUsername(e.target.value)} />
       </div>
-      <div>
-        <label>Password:</label>
-        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      <div className="space-y-2 mt-2">
+        <label className="block">Password:</label>
+        <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
       </div>
-      <button type="submit">Login</button>
+      <Button type="submit" className="mt-4">Login</Button>
       <div>
         <a href="/forgot-password">Forgot password?</a>
       </div>

--- a/frontend/pages/signup.js
+++ b/frontend/pages/signup.js
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { apiFetch } from '../lib/api';
+import { toast } from 'react-hot-toast';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
 
 export default function Signup() {
   const [username, setUsername] = useState('');
@@ -17,25 +20,25 @@ export default function Signup() {
       });
       router.push('/login');
     } catch (err) {
-      alert('Signup failed');
+      toast.error('Signup failed');
     }
   };
 
   return (
     <form onSubmit={handleSubmit}>
-      <div>
-        <label>Username:</label>
-        <input value={username} onChange={(e) => setUsername(e.target.value)} />
+      <div className="space-y-2">
+        <label className="block">Username:</label>
+        <Input value={username} onChange={(e) => setUsername(e.target.value)} />
       </div>
-      <div>
-        <label>Password:</label>
-        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      <div className="space-y-2 mt-2">
+        <label className="block">Password:</label>
+        <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
       </div>
-      <div>
-        <label>Role:</label>
-        <input value={role} onChange={(e) => setRole(e.target.value)} />
+      <div className="space-y-2 mt-2">
+        <label className="block">Role:</label>
+        <Input value={role} onChange={(e) => setRole(e.target.value)} />
       </div>
-      <button type="submit">Signup</button>
+      <Button type="submit" className="mt-4">Signup</Button>
     </form>
   );
 }

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -6,4 +6,7 @@
   html {
     @apply font-sans bg-gray-900 text-gray-100 scroll-smooth;
   }
+  body {
+    font-feature-settings: 'tnum' 1, 'case' 1, 'ss01' 1;
+  }
 }


### PR DESCRIPTION
## Summary
- add headless UI components for buttons, inputs, modals, skeletons and tables
- persist dark/light theme with localStorage toggle
- responsive app shell with mobile sidebar and ticker skeletons
- integrate toast notifications and remove legacy alerts
- ensure tables scroll on small screens and apply numeric font features

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe6886d7c8325b00010156274e7f6